### PR TITLE
fix(compose): yamllint-clean generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
+---
 services:
   gluetun:
     image: ${GLUETUN_IMAGE}
     container_name: gluetun
-    cap_add: ["NET_ADMIN"]
+    cap_add:
+      - NET_ADMIN
     devices:
       - /dev/net/tun
     environment:
@@ -77,7 +79,10 @@ services:
       gluetun:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${QBT_HTTP_PORT_CONTAINER}/api/v2/app/version"]
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${QBT_HTTP_PORT_CONTAINER}/api/v2/app/version"
       interval: 30s
       timeout: 10s
       retries: 5
@@ -93,59 +98,122 @@ services:
     image: ${SONARR_IMAGE}
     container_name: sonarr
     network_mode: "service:gluetun"
-    environment: { PUID: ${PUID}, PGID: ${PGID}, TZ: ${TIMEZONE} }
+    environment:
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TIMEZONE}
     volumes:
       - ${ARR_DOCKER_DIR}/sonarr:/config
       - ${TV_DIR}:/tv
       - ${DOWNLOADS_DIR}:/downloads
       - ${COMPLETED_DIR}:/completed
-    depends_on: { gluetun: { condition: service_healthy } }
-    healthcheck: { test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${SONARR_PORT}"], interval: 30s, timeout: 10s, retries: 5, start_period: 90s }
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${SONARR_PORT}"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
 
   radarr:
     image: ${RADARR_IMAGE}
     container_name: radarr
     network_mode: "service:gluetun"
-    environment: { PUID: ${PUID}, PGID: ${PGID}, TZ: ${TIMEZONE} }
+    environment:
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TIMEZONE}
     volumes:
       - ${ARR_DOCKER_DIR}/radarr:/config
       - ${MOVIES_DIR}:/movies
       - ${DOWNLOADS_DIR}:/downloads
       - ${COMPLETED_DIR}:/completed
-    depends_on: { gluetun: { condition: service_healthy } }
-    healthcheck: { test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${RADARR_PORT}"], interval: 30s, timeout: 10s, retries: 5, start_period: 90s }
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${RADARR_PORT}"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
 
   prowlarr:
     image: ${PROWLARR_IMAGE}
     container_name: prowlarr
     network_mode: "service:gluetun"
-    environment: { PUID: ${PUID}, PGID: ${PGID}, TZ: ${TIMEZONE} }
+    environment:
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TIMEZONE}
     volumes:
       - ${ARR_DOCKER_DIR}/prowlarr:/config
-    depends_on: { gluetun: { condition: service_healthy } }
-    healthcheck: { test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${PROWLARR_PORT}"], interval: 30s, timeout: 10s, retries: 5, start_period: 90s }
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${PROWLARR_PORT}"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
 
   bazarr:
     image: ${BAZARR_IMAGE}
     container_name: bazarr
     network_mode: "service:gluetun"
-    environment: { PUID: ${PUID}, PGID: ${PGID}, TZ: ${TIMEZONE} }
+    environment:
+      PUID: ${PUID}
+      PGID: ${PGID}
+      TZ: ${TIMEZONE}
     volumes:
       - ${ARR_DOCKER_DIR}/bazarr:/config
       - ${TV_DIR}:/tv
       - ${MOVIES_DIR}:/movies
-    depends_on: { gluetun: { condition: service_healthy } }
-    healthcheck: { test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${BAZARR_PORT}"], interval: 30s, timeout: 10s, retries: 5, start_period: 90s }
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${BAZARR_PORT}"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
 
   flaresolverr:
     image: ${FLARESOLVERR_IMAGE}
     container_name: flaresolverr
     network_mode: "service:gluetun"
-    environment: { LOG_LEVEL: info }
-    depends_on: { gluetun: { condition: service_healthy } }
-    healthcheck: { test: ["CMD", "curl", "-fsS", "http://${GLUETUN_LOOPBACK_HOST}:${FLARESOLVERR_PORT}"], interval: 30s, timeout: 10s, retries: 5, start_period: 90s }
+    environment:
+      LOG_LEVEL: info
+    depends_on:
+      gluetun:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS "http://${GLUETUN_LOOPBACK_HOST}:${FLARESOLVERR_PORT}"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- update compose generation to emit a YAML document start marker, block-style mappings, and folded CMD-SHELL health checks so yamllint passes
- run docker compose config and yamllint (when available) after writing the compose file to catch errors early
- refresh the checked-in docker-compose.yml to match the lint-friendly structure

## Testing
- yamllint -s docker-compose.yml *(fails: yamllint unavailable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cd44e5404883299c56ffeeac99ea75