### PR TITLE
Improve VPN reliability and diagnostics

### DIFF
--- a/.arraliases
+++ b/.arraliases
@@ -68,15 +68,21 @@ _arr_gluetun_api(){
   local host="$(_arr_gluetun_host)"
 
   if [ -z "$key" ]; then
-    echo "Warning: GLUETUN_API_KEY is unset; rerun arrstack to regenerate." >&2
+    echo "Error: GLUETUN_API_KEY not found. Run: ./arrstack.sh --rotate-api-key" >&2
     return 1
   fi
 
-  if curl -fsS -H "X-Api-Key: ${key}" "http://${host}:${port}${endpoint}" 2>/dev/null; then
+  local response
+  response=$(curl -fsS -H "X-Api-Key: ${key}" "http://${host}:${port}${endpoint}" 2>&1)
+  local result=$?
+
+  if [ $result -eq 0 ]; then
+    printf '%s\n' "$response"
     return 0
   fi
 
-  curl -fsS -u "gluetun:${key}" "http://${host}:${port}${endpoint}"
+  echo "API call failed. Check: docker logs gluetun" >&2
+  return 1
 }
 
 _arr_qbt_base(){

--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -26,7 +26,7 @@ PGID="${PGID:-$(id -g)}"
 TIMEZONE="${TIMEZONE:-Australia/Sydney}"
 LAN_IP="${LAN_IP:-}"
 LOCALHOST_IP="${LOCALHOST_IP:-127.0.0.1}"
-SERVER_COUNTRIES="${SERVER_COUNTRIES:-Netherlands,Switzerland}"
+SERVER_COUNTRIES="${SERVER_COUNTRIES:-Switzerland,Iceland,Romania,Czech Republic,Netherlands}"
 
 # Gluetun control server
 GLUETUN_CONTROL_PORT="${GLUETUN_CONTROL_PORT:-8000}"


### PR DESCRIPTION
## Summary
- tighten ProtonVPN defaults, Gluetun configuration, and service start-up checks to improve port forwarding reliability
- replace the Python-based alias templating with sed and generate a bundled VPN diagnostic helper script
- enhance the port-sync helper to retry intelligently and guide server selection when ProtonVPN fails to assign a port

## Testing
- bash -n arrstack.sh
- ./arrstack.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68ce6abf5ce483298adc6ae1013a000f