### PR TITLE
Improve qBittorrent authentication defaults

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -72,6 +72,42 @@ CFG
 ./arrstack.sh --yes
 ```
 
+## qBittorrent Authentication Issues
+
+### Getting Access Credentials
+
+qBittorrent generates a temporary password on first run or after a config reset:
+
+```bash
+# Method 1: Use the helper script
+${ARR_STACK_DIR}/scripts/qbt-helper.sh show
+
+# Method 2: Check logs directly
+docker logs qbittorrent 2>&1 | grep "temporary password" | tail -1
+```
+
+### Common Solutions
+
+1. **"Unauthorized" error**:
+   - You need the temporary password from logs
+   - URL must be `http://YOUR_IP:8081/` (external port)
+
+2. **Enable passwordless LAN access**:
+   ```bash
+   ${ARR_STACK_DIR}/scripts/qbt-helper.sh whitelist
+   ```
+
+3. **Reset authentication completely**:
+   ```bash
+   ${ARR_STACK_DIR}/scripts/qbt-helper.sh reset
+   ```
+
+### Important Notes
+- Port 8081 is the external port (use this in your browser)
+- Port 8080 is the internal port (inside the container)
+- Temporary passwords change with each restart
+- Always set a permanent password after first login and update `.env`
+
 ## Health and status
 ```bash
 # Container state

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# qBittorrent Helper - Manage authentication and access defaults
+
+set -euo pipefail
+
+log() {
+  printf '[%s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+warn() {
+  printf '[%s] WARNING: %s\n' "$(date '+%H:%M:%S')" "$*" >&2
+}
+
+die() {
+  warn "$1"
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_FILE="${STACK_DIR}/.env"
+CONTAINER_NAME="qbittorrent"
+
+load_env() {
+  if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+  fi
+}
+
+resolve_docker_data() {
+  local candidates=()
+
+  if [[ -n "${ARR_DOCKER_DIR:-}" ]]; then
+    candidates+=("$ARR_DOCKER_DIR")
+  fi
+  candidates+=("${HOME}/srv/docker-data" "${STACK_DIR}/docker-data")
+
+  local path
+  for path in "${candidates[@]}"; do
+    if [[ -n "$path" && -d "$path" ]]; then
+      printf '%s\n' "$path"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+temporary_password() {
+  docker logs "$CONTAINER_NAME" 2>&1 |
+    grep "temporary password" |
+    tail -1 |
+    sed 's/.*temporary password[^:]*: *//' |
+    awk '{print $1}'
+}
+
+webui_host() {
+  if [[ -n "${LAN_IP:-}" && "$LAN_IP" != "0.0.0.0" ]]; then
+    printf '%s' "$LAN_IP"
+  else
+    printf '%s' "127.0.0.1"
+  fi
+}
+
+webui_port() {
+  printf '%s' "${QBT_HTTP_PORT_HOST:-8081}"
+}
+
+config_file_path() {
+  printf '%s/qbittorrent/qBittorrent/qBittorrent.conf' "$DOCKER_DATA"
+}
+
+stop_container() {
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+start_container() {
+  docker start "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+derive_subnet() {
+  if [[ -n "${LAN_IP:-}" && "$LAN_IP" != "0.0.0.0" ]]; then
+    echo "$LAN_IP" | sed 's/\.[0-9]*$/.0\/24/'
+  fi
+}
+
+show_info() {
+  log "qBittorrent Access Information:"
+  log "================================"
+  log "URL: http://$(webui_host):$(webui_port)/"
+  log ""
+
+  local temp_pass
+  temp_pass=$(temporary_password || true)
+
+  if [[ -n "$temp_pass" ]]; then
+    log "Username: admin"
+    log "Password: ${temp_pass} (temporary - change this!)"
+  else
+    log "Username: ${QBT_USER:-admin}"
+    log "Password: ${QBT_PASS:-Check logs or use 'reset' command}"
+  fi
+}
+
+reset_auth() {
+  log "Resetting qBittorrent authentication..."
+  stop_container
+
+  local cfg
+  cfg=$(config_file_path)
+  if [[ -f "$cfg" ]]; then
+    local backup="${cfg}.bak.$(date +%Y%m%d_%H%M%S)"
+    cp "$cfg" "$backup"
+    log "  Backed up config to $backup"
+    sed -i '/WebUI\\Password_PBKDF2/d' "$cfg" || true
+  else
+    warn "Config file not found at $cfg; proceeding without backup"
+  fi
+
+  start_container
+  sleep 5
+
+  local temp_pass
+  temp_pass=$(temporary_password || true)
+
+  if [[ -n "$temp_pass" ]]; then
+    log "Authentication reset. New temporary password: ${temp_pass}"
+  else
+    warn "Unable to detect temporary password automatically. Check 'docker logs qbittorrent'."
+  fi
+}
+
+update_whitelist() {
+  local subnet
+  subnet=$(derive_subnet)
+
+  if [[ -z "$subnet" ]]; then
+    die "LAN_IP is not set to a private address; cannot derive whitelist subnet"
+  fi
+
+  log "Enabling LAN whitelist for passwordless access..."
+  stop_container
+
+  local cfg
+  cfg=$(config_file_path)
+  if [[ -f "$cfg" ]]; then
+    local tmp
+    tmp=$(mktemp)
+    awk '!(/^WebUI\\AuthSubnetWhitelistEnabled=/ || /^WebUI\\AuthSubnetWhitelist=/)' "$cfg" >"$tmp"
+    {
+      printf 'WebUI\\AuthSubnetWhitelistEnabled=true\n'
+      printf 'WebUI\\AuthSubnetWhitelist=%s\n' "$subnet"
+    } >>"$tmp"
+    mv "$tmp" "$cfg"
+  else
+    warn "Config file not found at $cfg; whitelist not updated"
+  fi
+
+  start_container
+  log "LAN whitelist enabled for: $subnet"
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: qbt-helper.sh {show|reset|whitelist}
+  show       Display current access information
+  reset      Reset authentication (generates a new temporary password)
+  whitelist  Enable passwordless access from the LAN subnet
+USAGE
+}
+
+main() {
+  load_env
+
+  DOCKER_DATA=$(resolve_docker_data) || die "Cannot find docker-data directory"
+  export DOCKER_DATA
+
+  case "${1:-show}" in
+    show)
+      show_info
+      ;;
+    reset)
+      reset_auth
+      ;;
+    whitelist)
+      update_whitelist
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- detect docker-data located under ~/srv when ARR_DOCKER_DIR is unset and record the stack directory accordingly
- streamline qBittorrent config generation with a single template, persist randomized credentials, and disable WebUI UPnP explicitly
- install the modular qBittorrent helper script from the tracked template and expose its commands without duplicating inline script content

## Testing
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68cf5ffb40d4832992dd98b44f2ca151