### PR TITLE
Fix qBittorrent config path for VueTorrent

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -939,9 +939,24 @@ write_qbt_helper_script() {
 
 write_qbt_config() {
   msg "🧩 Writing qBittorrent config"
-  local config_dir="${ARR_DOCKER_DIR}/qbittorrent/qBittorrent"
+  local config_dir="${ARR_DOCKER_DIR}/qbittorrent"
+  local runtime_dir="${config_dir}/qBittorrent"
   local conf_file="${config_dir}/qBittorrent.conf"
+  local legacy_conf="${runtime_dir}/qBittorrent.conf"
+
   ensure_dir "$config_dir"
+  ensure_dir "$runtime_dir"
+
+  if [[ -f "$legacy_conf" && ! -f "$conf_file" ]]; then
+    msg "  Migrating legacy config from ${legacy_conf}"
+    mv "$legacy_conf" "$conf_file"
+    chmod 600 "$conf_file"
+  fi
+
+  if [[ -f "$legacy_conf" ]]; then
+    msg "  Removing unused legacy config at ${legacy_conf}"
+    rm -f "$legacy_conf"
+  fi
   local auth_whitelist
   auth_whitelist="$(calculate_qbt_auth_whitelist)"
   msg "  Stored WebUI auth whitelist entries: ${auth_whitelist}"

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -70,7 +70,7 @@ webui_port() {
 }
 
 config_file_path() {
-  printf '%s/qbittorrent/qBittorrent/qBittorrent.conf' "$DOCKER_DATA"
+  printf '%s/qbittorrent/qBittorrent.conf' "$DOCKER_DATA"
 }
 
 stop_container() {


### PR DESCRIPTION
## Summary
- write the qBittorrent config to docker-data/qbittorrent/qBittorrent.conf, migrating and cleaning up any nested legacy file while still seeding VueTorrent defaults
- keep the runtime qBittorrent directory for container data and adjust the helper script to manage credentials against the live config file

## Testing
- ./arrstack.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68cfa71c5ecc8329ae5df63ec55edd5f