### PR TITLE
Refine shell aliases and drop python dependencies

### DIFF
--- a/.arraliases
+++ b/.arraliases
@@ -105,22 +105,40 @@ _arr_qbt_auth(){
 _arr_api_key(){
   local svc="$1"
   local file="${ARR_DOCKER_DIR}/${svc}/config.xml"
+  local key
+
   [ -f "$file" ] || return 1
-  python3 - "$file" <<'PY' 2>/dev/null
-import sys
-import xml.etree.ElementTree as ET
-tree = ET.parse(sys.argv[1])
-root = tree.getroot()
-key = root.findtext('ApiKey') or ''
-print(key.strip())
-PY
+
+  key="$(awk '
+    /<ApiKey>/ {
+      line=$0
+      sub(/.*<ApiKey>[[:space:]]*/, "", line)
+      sub(/[[:space:]]*<\/ApiKey>.*/, "", line)
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      print line
+      exit
+    }
+  ' "$file" 2>/dev/null)"
+
+  [ -n "$key" ] || return 1
+  printf '%s\n' "$key"
 }
+
+arr.compose(){ _arr_compose "$@"; }
 
 arr.up(){ _arr_compose up -d "$@"; }
 arr.down(){ _arr_compose down "$@"; }
 arr.restart(){ if [ $# -eq 0 ]; then _arr_compose restart "${_arr_services[@]}"; else _arr_compose restart "$@"; fi }
 arr.pull(){ _arr_compose pull "$@"; }
-arr.logs(){ _arr_compose logs -f "$@"; }
+arr.logs(){
+  local tail_args=()
+  if [ $# -gt 0 ] && [ "${1#*[!0-9]}" = "$1" ]; then
+    tail_args=(--tail "$1")
+    shift
+  fi
+  _arr_compose logs "${tail_args[@]}" -f "$@"
+}
 arr.ps(){ _arr_compose ps "$@"; }
 arr.stats(){ docker stats "${_arr_services[@]}" "$@"; }
 arr.shell(){
@@ -151,6 +169,76 @@ arr.backup(){
   done
   printf 'Backups stored in %s\n' "$dest"
 }
+
+arr.compose.config(){ _arr_compose config "$@"; }
+
+arr.env.get(){
+  if [ -z "${1:-}" ]; then
+    printf 'Usage: arr.env.get <KEY>\n' >&2
+    return 1
+  fi
+  local value
+  value="$(_arr_env_get "$1")" || true
+  if [ -n "$value" ]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
+arr.env.set(){
+  if [ $# -lt 2 ]; then
+    printf 'Usage: arr.env.set <KEY> <VALUE>\n' >&2
+    return 1
+  fi
+  local key="$1"
+  shift
+  local value="$*"
+  local tmp
+  tmp="$(mktemp)"
+  [ -n "$tmp" ] || { echo 'mktemp failed' >&2; return 1; }
+  if [ -f "$ARR_ENV_FILE" ]; then
+    awk -v k="$key" -v v="$value" '
+      BEGIN { done=0 }
+      /^[[:space:]]*#/ { print; next }
+      $0 ~ ("^" k "=") { print k "=" v; done=1; next }
+      { print }
+      END { if (!done) print k "=" v }
+    ' "$ARR_ENV_FILE" >"$tmp"
+  else
+    printf '%s=%s\n' "$key" "$value" >"$tmp"
+  fi
+  if ! mv "$tmp" "$ARR_ENV_FILE"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  printf '%s=%s\n' "$key" "$value"
+}
+
+arr.env.list(){
+  if [ ! -f "$ARR_ENV_FILE" ]; then
+    printf 'Missing %s\n' "$ARR_ENV_FILE" >&2
+    return 1
+  fi
+  sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$ARR_ENV_FILE" | sort
+}
+
+arr.data.usage(){
+  local dirs=()
+  if [ ! -d "$ARR_DOCKER_DIR" ]; then
+    printf 'Missing %s\n' "$ARR_DOCKER_DIR" >&2
+    return 1
+  fi
+  while IFS= read -r -d '' path; do
+    dirs+=("$path")
+  done < <(find "$ARR_DOCKER_DIR" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+  if [ ${#dirs[@]} -eq 0 ]; then
+    printf 'No service data directories found in %s\n' "$ARR_DOCKER_DIR"
+    return 0
+  fi
+  du -sh "${dirs[@]}" 2>/dev/null | sort -h
+}
+
 arr.open(){
   local host="$(_arr_host)"
   local entries='qBittorrent QBT_HTTP_PORT_HOST 8081
@@ -221,19 +309,62 @@ glue.pf(){ _arr_gluetun_api /v1/openvpn/portforwarded && printf '\n'; }
 glue.health(){ docker inspect --format '{{.State.Health.Status}}' gluetun 2>/dev/null || echo unknown; }
 
 arr_vpn_servers(){
-  command -v python3 >/dev/null 2>&1 || { echo "python3 is required"; return 1; }
+  local limit="${1:-20}"
   local payload
-  payload="$(docker exec gluetun cat /gluetun/servers.json 2>/dev/null)" || { echo "Unable to read gluetun server catalog"; return 1; }
-  printf '%s' "$payload" | python3 - <<'PY' 2>/dev/null || { echo "Unable to parse server catalog"; return 1; }
-import json, sys
-try:
-    data=json.load(sys.stdin)
-except json.JSONDecodeError:
-    sys.exit(1)
-servers=data.get('openvpn', {}).get('protonvpn', [])
-for server in servers[:20]:
-    print(f"{server.get('name','?')} - {server.get('country','?')} ({server.get('region','?')})")
-PY
+
+  case "$limit" in
+    ''|*[!0-9]*) limit=20 ;;
+  esac
+
+  if docker exec gluetun /bin/sh -c 'command -v gluetun >/dev/null 2>&1' >/dev/null 2>&1; then
+    docker exec gluetun /bin/sh -c "gluetun servers --format table --limit ${limit}" 2>/dev/null || {
+      echo "Unable to query gluetun CLI for server catalog" >&2
+      return 1
+    }
+    return 0
+  fi
+
+  payload="$(docker exec gluetun cat /gluetun/servers.json 2>/dev/null)" || {
+    echo "Unable to read gluetun server catalog" >&2
+    return 1
+  }
+
+  printf '%s\n' "$payload" | awk -v limit="$limit" '
+    BEGIN {
+      count=0
+      name=""
+      country=""
+      region=""
+    }
+    /"name"[[:space:]]*:/ {
+      name=$0
+      sub(/.*"name"[[:space:]]*:[[:space:]]*"/, "", name)
+      sub(/".*/, "", name)
+    }
+    /"country"[[:space:]]*:/ {
+      country=$0
+      sub(/.*"country"[[:space:]]*:[[:space:]]*"/, "", country)
+      sub(/".*/, "", country)
+    }
+    /"region"[[:space:]]*:/ {
+      region=$0
+      sub(/.*"region"[[:space:]]*:[[:space:]]*"/, "", region)
+      sub(/".*/, "", region)
+      if (name != "" && country != "" && region != "") {
+        printf "%s - %s (%s)\n", name, country, region
+        count++
+        if (count >= limit) {
+          exit
+        }
+        name=""
+        country=""
+        region=""
+      }
+    }
+  ' || {
+    echo "Unable to parse server catalog" >&2
+    return 1
+  }
 }
 
 arr_vpn_country(){
@@ -265,7 +396,16 @@ _qbt_call(){
 }
 
 qbt.url(){ printf '%s\n' "$(_arr_qbt_base)"; }
-qbt.port.get(){ command -v python3 >/dev/null 2>&1 || { echo "python3 is required"; return 1; }; _qbt_call GET /api/v2/app/preferences | python3 -c "import json,sys;print(json.load(sys.stdin).get('listen_port','unknown'))" 2>/dev/null; }
+qbt.port.get(){
+  local json value
+  json="$(_qbt_call GET /api/v2/app/preferences 2>/dev/null)" || return 1
+  value="$(printf '%s\n' "$json" | sed -n 's/.*"listen_port"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+  if [ -n "$value" ]; then
+    printf '%s\n' "$value"
+  else
+    echo "unknown"
+  fi
+}
 qbt.port.set(){
   if [ -z "$1" ]; then
     printf 'Usage: qbt.port.set <port>\n' >&2
@@ -283,7 +423,15 @@ qbt.port.sync(){
   fi
   qbt.port.set "$port"
 }
-qbt.list(){ command -v python3 >/dev/null 2>&1 || { echo "python3 is required"; return 1; }; _qbt_call GET /api/v2/torrents/info | python3 -c "import json,sys;print('\n'.join(t.get('name','') for t in json.load(sys.stdin)))" 2>/dev/null; }
+qbt.list(){
+  local payload entries
+  payload="$(_qbt_call GET /api/v2/torrents/info 2>/dev/null)" || return 1
+  entries=$(printf '%s' "$payload" | tr -d '\n' | grep -o '"name":"[^"]*"' 2>/dev/null || true)
+  if [ -z "$entries" ]; then
+    return 0
+  fi
+  printf '%s\n' "$entries" | cut -d'"' -f4
+}
 qbt.pause.all(){ _qbt_call POST /api/v2/torrents/pause --data 'hashes=all'; }
 qbt.resume.all(){ _qbt_call POST /api/v2/torrents/resume --data 'hashes=all'; }
 qbt.reannounce(){ _qbt_call POST /api/v2/torrents/reannounce --data 'hashes=all'; }

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -1166,6 +1166,11 @@ services:
       retries: 5
       start_period: 60s
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   qbittorrent:
     image: ${QBITTORRENT_IMAGE}
@@ -1184,6 +1189,11 @@ services:
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   sonarr:
     image: ${SONARR_IMAGE}
@@ -1203,6 +1213,11 @@ services:
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   radarr:
     image: ${RADARR_IMAGE}
@@ -1222,6 +1237,11 @@ services:
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   prowlarr:
     image: ${PROWLARR_IMAGE}
@@ -1238,6 +1258,11 @@ services:
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   bazarr:
     image: ${BAZARR_IMAGE}
@@ -1257,6 +1282,11 @@ __BAZARR_OPTIONAL_SUBS__
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   flaresolverr:
     image: ${FLARESOLVERR_IMAGE}
@@ -1268,6 +1298,11 @@ __BAZARR_OPTIONAL_SUBS__
       gluetun:
         condition: service_healthy
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
 
   port-sync:
     image: alpine:3.20.3
@@ -1289,6 +1324,12 @@ __BAZARR_OPTIONAL_SUBS__
       - gluetun
       - qbittorrent
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "1m"
+        max-file: "3"
+
 YAML
   )"
 


### PR DESCRIPTION
## Summary
- replace python helpers in the shared aliases with awk/sed/grep alternatives, including XML and JSON parsing
- add compose, environment, and data-usage convenience helpers to the alias set

## Testing
- bash -n arrstack.sh
- bash -n .arraliases

------
https://chatgpt.com/codex/tasks/task_e_68d01926d8d08329b202c2a88f6a3b5c