### PR TITLE
Restore installer logging with rotation

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -6,6 +6,8 @@
 ARR_BASE="${ARR_BASE:-${HOME}/srv}"
 ARR_STACK_DIR="${ARR_STACK_DIR:-${ARR_BASE}/arrstack}"
 ARR_ENV_FILE="${ARR_ENV_FILE:-${ARR_STACK_DIR}/.env}"
+ARR_LOG_DIR="${ARR_LOG_DIR:-${ARR_STACK_DIR}/logs}"
+ARR_INSTALL_LOG="${ARR_INSTALL_LOG:-${ARR_LOG_DIR}/arrstack-install.log}"
 ARR_DOCKER_DIR="${ARR_DOCKER_DIR:-${ARR_BASE}/docker-data}"
 ARRCONF_DIR="${ARRCONF_DIR:-${PWD}/arrconf}"
 


### PR DESCRIPTION
## Summary
- add default configuration values for the installer log directory and file
- reintroduce installer logging with rotation to arrstack.sh and pipe output through tee

## Testing
- bash -n arrstack.sh

------
https://chatgpt.com/codex/tasks/task_e_68d07467f998832992758725b4ae4fcd