### PR TITLE
Add sudo-driven firewall helper and align Proton OpenVPN config

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The tables below summarise every configurable input exposed by `arrstack.sh` tog
 | `TIMEZONE` | `Australia/Sydney` | Align container logs and cron tasks with your local timezone. |
 | `LAN_IP` | Auto-detected (falls back to `0.0.0.0`) | Bind services to a specific RFC1918 address instead of all interfaces. |
 | `LOCALHOST_IP` | `127.0.0.1` | Change where the Gluetun control API binds on the host (advanced). |
+| `VPN_SERVICE_PROVIDER` | `protonvpn` | Keep Gluetun pinned to ProtonVPN. Change only when migrating to a different supported provider. |
+| `VPN_TYPE` | `openvpn` | Force Gluetun to use Proton's OpenVPN stack (required for port forwarding). |
 | `SERVER_COUNTRIES` | `Switzerland,Iceland,Romania,Czech Republic,Netherlands` | Limit ProtonVPN exits to countries that support port forwarding or suit your latency. |
 | `GLUETUN_CONTROL_PORT` | `8000` | Adjust the host port for the Gluetun control API when 8000 is taken. |
 


### PR DESCRIPTION
## Summary
- add a sudo-aware firewall remediation helper so the installer can set UDP/5351 rules and persist them when users opt in
- expose Proton OpenVPN credentials and provider settings in the generated .env and compose template to follow Gluetun guidance
- document the VPN provider/type controls alongside other networking variables

## Testing
- bash -n arrstack.sh
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d07d51e5cc8329b002a155c1bfba37