### PR TITLE
Add missing networking defaults

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -32,6 +32,8 @@ PGID="${PGID:-$(id -g)}"
 TIMEZONE="${TIMEZONE:-Australia/Sydney}"
 LAN_IP="${LAN_IP:-}"
 LOCALHOST_IP="${LOCALHOST_IP:-127.0.0.1}"
+VPN_SERVICE_PROVIDER="${VPN_SERVICE_PROVIDER:-protonvpn}"
+VPN_TYPE="${VPN_TYPE:-openvpn}"
 SERVER_COUNTRIES="${SERVER_COUNTRIES:-Switzerland,Iceland,Romania,Czech Republic,Netherlands}"
 
 # Gluetun control server
@@ -66,3 +68,4 @@ FLARESOLVERR_IMAGE="${FLARESOLVERR_IMAGE:-ghcr.io/flaresolverr/flaresolverr:v3.3
 # Behaviour flags
 ASSUME_YES="${ASSUME_YES:-0}"
 FORCE_ROTATE_API_KEY="${FORCE_ROTATE_API_KEY:-0}"
+FORCE_COLOR="${FORCE_COLOR:-}"

--- a/arrconf/userconf.sh.example
+++ b/arrconf/userconf.sh.example
@@ -27,6 +27,8 @@ TIMEZONE="Australia/Sydney"            # Timezone for container logs and schedul
 # --- Networking ---
 LAN_IP=""                              # Bind services to one LAN IP (leave blank to listen on all)
 LOCALHOST_IP="127.0.0.1"               # Loopback used by the Gluetun control API
+VPN_SERVICE_PROVIDER="protonvpn"       # Gluetun VPN provider (stick with protonvpn for native port forwarding)
+VPN_TYPE="openvpn"                     # ProtonVPN transport (OpenVPN required for port forwarding support)
 SERVER_COUNTRIES="Switzerland,Iceland,Romania,Czech Republic,Netherlands"  # ProtonVPN exit country list
 GLUETUN_CONTROL_PORT="8000"            # Host port that exposes the Gluetun control API
 
@@ -57,3 +59,4 @@ FLARESOLVERR_PORT="8191"               # FlareSolverr service port exposed on th
 # --- Behaviour toggles ---
 # ASSUME_YES="0"                         # Skip confirmation prompts when scripting installs
 # FORCE_ROTATE_API_KEY="0"               # Force regeneration of the Gluetun API key on next run
+# FORCE_COLOR=""                         # Set to 1 to keep coloured output when piping/redirecting logs


### PR DESCRIPTION
## Summary
- add VPN_SERVICE_PROVIDER and VPN_TYPE defaults so networking options from the README can be overridden
- expose the FORCE_COLOR toggle in both default and example user configuration files

## Testing
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d094bffbf08329903f6cf668fdea63