### PR TITLE
Improve Caddy auth rotation and credential handling

### DIFF
--- a/images/port-sync/Dockerfile
+++ b/images/port-sync/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.20
+RUN apk add --no-cache curl ca-certificates \
+ && update-ca-certificates
+WORKDIR /app
+# The stack mounts /port-sync.sh at runtime; no copy needed.
+ENTRYPOINT ["/bin/sh","-c","/port-sync.sh"]


### PR DESCRIPTION
## Summary
- add helper utilities to sanitize Caddy credentials, reuse existing hashes, and auto-regenerate bcrypt passwords when missing or forced
- persist new credentials by writing plaintext to a protected credentials file, storing only the hash in `.env`, and wiring a `--rotate-caddy-auth` flag
- document the new rotation flow and credentials location in the README

## Testing
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d0e51b02d08329aa34ae60e6b5780e