### PR TITLE
Improve port-sync image defaults and runtime bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,8 @@ Only the Caddy reverse proxy is published on the LAN (ports 80/443). Every appli
    ```
    Replace the placeholders with your Proton VPN username and password (the installer tightens the file permissions automatically).
 3. **(Optional) Adjust defaults before installation.** Copy `arrconf/userconf.sh.example` to `arrconf/userconf.sh` and tweak values such as `LAN_IP`, `SERVER_COUNTRIES`, media directories, or host port overrides. Skip this if the defaults suit you—the installer can be rerun whenever you want to apply changes.
-4. **Build the port-sync helper image once.**
-   ```bash
-   docker build -t local/port-sync:alpine-curl images/port-sync
-   ```
-   This tiny Alpine build includes `curl` so the `port-sync` sidecar can run without installing packages at startup.
+4. **(Optional) Customize the port-sync helper image.**
+   The default `alpine:3.20.3` boots fine and installs `curl` on the fly. If you prefer a pre-baked image (for example one built with `curl`/CA bundles already present), publish it to your registry of choice and set `PORT_SYNC_IMAGE=your/image:tag` in `arrconf/userconf.sh` (a minimal Dockerfile just needs `FROM alpine:3.20` plus `apk add --no-cache curl ca-certificates`).
 5. **Run the installer.**
    ```bash
    ./arrstack.sh

--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -62,6 +62,11 @@ RADARR_IMAGE="${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.27.5.10198-ls283}"
 PROWLARR_IMAGE="${PROWLARR_IMAGE:-lscr.io/linuxserver/prowlarr:latest}"
 BAZARR_IMAGE="${BAZARR_IMAGE:-lscr.io/linuxserver/bazarr:latest}"
 FLARESOLVERR_IMAGE="${FLARESOLVERR_IMAGE:-ghcr.io/flaresolverr/flaresolverr:v3.3.21}"
+#
+# Port-sync helper sidecar image:
+# - Default uses upstream Alpine and installs curl at runtime (robust path)
+# - If you want a pre-baked local image, set: PORT_SYNC_IMAGE=local/port-sync:alpine-curl
+PORT_SYNC_IMAGE="${PORT_SYNC_IMAGE:-alpine:3.20.3}"
 
 # Behaviour flags
 ASSUME_YES="${ASSUME_YES:-0}"

--- a/images/port-sync/Dockerfile
+++ b/images/port-sync/Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:3.20
-RUN apk add --no-cache curl ca-certificates \
- && update-ca-certificates
-WORKDIR /app
-# The stack mounts /port-sync.sh at runtime; no copy needed.
-ENTRYPOINT ["/bin/sh","-c","/port-sync.sh"]


### PR DESCRIPTION
## Summary
- default port-sync sidecar image to upstream `alpine:3.20.3` and persist the choice into `.env`
- validate `PORT_SYNC_IMAGE` alongside other container images and expose the setting in user defaults/documentation
- harden the port-sync bootstrap script by installing curl/CA bundles when missing and falling back to a wget-based shim
- remove the obsolete port-sync Dockerfile and briefly document how to point `PORT_SYNC_IMAGE` at a custom build

## Testing
- bash -n arrstack.sh

------
https://chatgpt.com/codex/tasks/task_e_68d104ec8ba08329a98855f12db95273