### PR TITLE
Add local DNS service and diagnostics

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -34,6 +34,16 @@ LAN_IP="${LAN_IP:-}"
 LOCALHOST_IP="${LOCALHOST_IP:-127.0.0.1}"
 SERVER_COUNTRIES="${SERVER_COUNTRIES:-Switzerland,Iceland,Romania,Czech Republic,Netherlands}"
 
+# Domain suffix used by Caddy hostnames (default to RFC 8375 recommendation)
+LAN_DOMAIN_SUFFIX="${LAN_DOMAIN_SUFFIX:-home.arpa}"
+
+# Upstream DNS resolvers for fallback
+UPSTREAM_DNS_1="${UPSTREAM_DNS_1:-1.1.1.1}"
+UPSTREAM_DNS_2="${UPSTREAM_DNS_2:-1.0.0.1}"
+
+# Enable internal local DNS resolver service
+ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS:-1}"
+
 # Gluetun control server
 GLUETUN_CONTROL_PORT="${GLUETUN_CONTROL_PORT:-8000}"
 GLUETUN_API_KEY="${GLUETUN_API_KEY:-}"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Diagnostics for LAN DNS + Caddy access
+
+SUFFIX="${LAN_DOMAIN_SUFFIX:-}"
+DNS_IP="${LAN_IP:-127.0.0.1}"
+
+printf '[doctor] LAN domain suffix: %s\n' "${SUFFIX:-<unset>}"
+printf '[doctor] Using DNS server at: %s\n' "${DNS_IP}"
+
+echo "[doctor] Checking if port 53 is free (or already bound):"
+if command -v ss >/dev/null 2>&1; then
+  if ss -ulpn 2>/dev/null | grep -q ':53 '; then
+    echo "[doctor][warn] Something is listening on port 53. Could conflict with local_dns service."
+  else
+    echo "[doctor][ok] Port 53 appears free."
+  fi
+else
+  echo "[doctor][warn] 'ss' command not found; skipping port 53 check."
+fi
+
+echo "[doctor] Testing DNS resolution of qbittorrent.${SUFFIX} via local resolver"
+res="$(dig +short @"${DNS_IP}" qbittorrent."${SUFFIX}" 2>/dev/null || true)"
+if ! command -v dig >/dev/null 2>&1; then
+  echo "[doctor][warn] 'dig' command not found; skipping DNS lookup."
+elif [ -z "${res}" ]; then
+  echo "[doctor][error] qbittorrent.${SUFFIX} did NOT resolve via ${DNS_IP}"
+else
+  echo "[doctor][ok] qbittorrent.${SUFFIX} resolves to ${res}"
+fi
+
+echo "[doctor] Testing HTTPS endpoint"
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[doctor][warn] 'curl' command not found; skipping HTTPS probe."
+elif curl -k --silent --max-time 5 "https://qbittorrent.${SUFFIX}/" -o /dev/null; then
+  echo "[doctor][ok] HTTPS endpoint reachable"
+else
+  echo "[doctor][warn] HTTPS endpoint not reachable. Could be DNS, Caddy, or firewall issue."
+fi
+
+exit 0

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -70,7 +70,7 @@ webui_port() {
 }
 
 webui_domain() {
-  local suffix="${CADDY_DOMAIN_SUFFIX:-lan}"
+  local suffix="${CADDY_DOMAIN_SUFFIX:-home.arpa}"
   suffix="${suffix#.}"
   printf 'qbittorrent.%s' "$suffix"
 }


### PR DESCRIPTION
## Summary
- default the stack to the RFC 8375 `.home.arpa` suffix and expose overrides for LAN DNS behaviour
- add an optional dnsmasq-based `local_dns` compose service plus doctor checks to validate LAN reachability
- document LAN access workflow, new DNS variables, and refresh helper defaults such as qbt-helper hostname output

## Testing
- bash -n arrstack.sh
- bash -n scripts/doctor.sh
- bash -n scripts/qbt-helper.sh

------
https://chatgpt.com/codex/tasks/task_e_68d128f5a41c83299ca7849d431ea683