### PR TITLE
Bind Gluetun control API for namespace access

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -1324,7 +1324,7 @@ services:
       SERVER_COUNTRIES: ${SERVER_COUNTRIES}
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: protonvpn
-      HTTP_CONTROL_SERVER_ADDRESS: 127.0.0.1:${GLUETUN_CONTROL_PORT}
+      HTTP_CONTROL_SERVER_ADDRESS: 0.0.0.0:${GLUETUN_CONTROL_PORT}
       HTTP_CONTROL_SERVER_AUTH: "apikey"
       HTTP_CONTROL_SERVER_APIKEY: ${GLUETUN_API_KEY}
       VPN_PORT_FORWARDING_STATUS_FILE: /tmp/gluetun/forwarded_port
@@ -1574,7 +1574,17 @@ __BAZARR_OPTIONAL_SUBS__
       gluetun:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1/healthz"]
+      test:
+        - "CMD-SHELL"
+        - >
+          if command -v curl >/dev/null 2>&1; then
+            curl -fsS http://127.0.0.1/healthz;
+          elif command -v wget >/dev/null 2>&1; then
+            wget -qO- http://127.0.0.1/healthz;
+          else
+            echo "missing http client" >&2;
+            exit 1;
+          fi
       interval: 15s
       timeout: 5s
       retries: 6

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -64,6 +64,20 @@ docker logs port-sync --tail 50
 ```
 If the helper reports authentication failures, confirm that `QBT_USER`/`QBT_PASS` in `.env` match the WebUI credentials. LAN browsers traverse Caddy, so the qBittorrent “bypass” checkboxes are optional. Gluetun also executes `/gluetun/hooks/update-qbt-port.sh` whenever Proton allocates a new port—if the hook is missing or not executable, rerun the installer.
 
+#### Control API unreachable inside the Gluetun namespace
+- Make sure `HTTP_CONTROL_SERVER_ADDRESS` in `docker-compose.yml` is bound to `0.0.0.0`. Recent releases of the installer do this automatically—rerun `./arrstack.sh --yes` to regenerate Compose files if you still see `127.0.0.1`.
+- Regenerate the stack after editing and restart just Gluetun first so the control server is reachable before other services start:
+  ```bash
+  docker compose down
+  docker compose up -d gluetun
+  sleep 20
+  docker compose up -d
+  ```
+- From the host, verify that the control server answers inside the namespace (swap in `wget -qO-` if `curl` is unavailable):
+  ```bash
+  docker compose exec -T gluetun curl -fsS "http://127.0.0.1:${GLUETUN_CONTROL_PORT:-8000}/v1/publicip/ip"
+  ```
+
 #### Port forwarding timeouts or RPC failures
 - Inspect Gluetun logs for NAT-PMP activity to spot slow or stalled negotiations:
   ```bash
@@ -71,10 +85,25 @@ If the helper reports authentication failures, confirm that `QBT_USER`/`QBT_PASS
   ```
 - Confirm `.env` still contains a Proton username with the `+pmp` suffix. The installer adds it automatically, but edits to `.env` can remove it and prevent Proton from enabling port forwarding.
 - Ensure `/gluetun/hooks/update-qbt-port.sh` exists and is executable inside the Gluetun container (rerun the installer if it is missing). The hook uses the qBittorrent Web API directly, so keep `.env` credentials accurate for seamless authentication.
-- Switch to another Proton exit in `arrconf/userconf.sh` by adjusting `SERVER_COUNTRIES`. Busy servers are more likely to drop the UDP 5351 NAT-PMP handshake.
+- Switch to another Proton exit in `arrconf/userconf.sh` by adjusting `SERVER_COUNTRIES`. Busy servers are more likely to drop the UDP 5351 NAT-PMP handshake. Narrowing the list to a single country (for example, `SERVER_COUNTRIES="Netherlands"`) usually makes Proton assign a port faster.
 - Give the tunnel time to settle. Port-sync uses exponential backoff (up to five minutes) and will automatically apply the forwarded port as soon as Gluetun reports it.
 - Keep the control API locked down: `GLUETUN_API_KEY` must be present and `LOCALHOST_IP` should stay on a loopback or other trusted address. Gluetun 3.40+ enforces authentication on `/v1/openvpn/portforwarded`, and the stack already ships with API-key protection—regenerate the key with `./arrstack.sh --rotate-api-key --yes` if required.
 - If Proton still never assigns a port, double-check that nothing on the host blocks outbound UDP 5351 to 10.16.0.1.
+
+### Caddy reports as unhealthy
+- Confirm the generated `Caddyfile` still contains the health responder block:
+  ```caddy
+  :80 {
+      respond /healthz 200 {
+          body "ok"
+      }
+  }
+  ```
+- Gluetun's namespace isolates services; use the control server namespace to probe Caddy directly if the healthcheck keeps failing (swap in `wget -qO-` if you prefer):
+  ```bash
+  docker compose exec -T gluetun curl -fsS http://127.0.0.1/healthz
+  ```
+- The healthcheck falls back to either `curl` or `wget`; if you build a custom image that strips both clients, install one or adjust the check accordingly.
 
 
 ### Services exposed on all interfaces


### PR DESCRIPTION
## Summary
- bind Gluetun's control API to 0.0.0.0 so other containers in the namespace can reach it
- harden the Caddy healthcheck to fall back to either curl or wget while keeping the health responder block
- document recovery steps for control API connectivity, Proton server selection, and Caddy health failures

## Testing
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d14a948964832990f686f5579ab6ea