### PR TITLE
feat: harden lan dns distribution and ca handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ You can combine the first four flags as needed—for example, `./arrstack.sh --y
 
 ## ✅ LAN DNS: choose one (set in `DNS_DISTRIBUTION_MODE`)
 
-**Option A — `router` (recommended):** Configure your router’s DHCP (Option 6) to hand out `${LAN_IP}` so every client uses the bundled resolver automatically. TP-Link’s VX230v exposes DNS fields in its web UI, though the exact page varies by firmware.[^tplink]
+`arrstack-mini` ships a dnsmasq resolver that answers `*.${LAN_DOMAIN_SUFFIX}` (`home.arpa` by default). Decide how clients learn `${LAN_IP}`:
 
-**Option B — `per-device`:** Leave the router unchanged and set DNS=`${LAN_IP}` on laptops, TVs, consoles, and similar devices. On Android, keep **Private DNS** set to **Off** or **Automatic**—entering a hostname forces DNS-over-TLS through an external provider and bypasses local records.[^android]
+- **`router` (recommended):** Point your router’s DHCP server at `${LAN_IP}` with a public resolver as the fallback. Follow the step-by-step checklist in [docs/ROUTER_DNS_SETUP.md](docs/ROUTER_DNS_SETUP.md) to apply the change safely; TP-Link VX230v instructions are included.[^tplink]
+- **`per-device`:** Leave the router untouched and manually set DNS=`${LAN_IP}` on key devices (Android/PC/TV). Keep Android **Private DNS** set to **Off** or **Automatic** so queries stay on the LAN.[^android]
 
 Set your preference in `arrconf/userconf.sh`:
 

--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -67,6 +67,11 @@ UPSTREAM_DNS_2="${UPSTREAM_DNS_2:-1.0.0.1}"
 # Enable internal local DNS resolver service
 ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS:-1}"
 
+# How LAN clients learn the resolver address
+#   router     – configure DHCP Option 6 on your router to ${LAN_IP}
+#   per-device – leave router DNS untouched and set DNS=${LAN_IP} on important clients
+DNS_DISTRIBUTION_MODE="${DNS_DISTRIBUTION_MODE:-router}"
+
 # Reverse proxy hostnames (Caddy defaults to LAN suffix when unset)
 CADDY_DOMAIN_SUFFIX="${CADDY_DOMAIN_SUFFIX:-${LAN_DOMAIN_SUFFIX}}"
 CADDY_LAN_CIDRS="${CADDY_LAN_CIDRS:-127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}"

--- a/arrconf/userconf.sh.example
+++ b/arrconf/userconf.sh.example
@@ -34,6 +34,7 @@ SERVER_COUNTRIES="Switzerland,Iceland,Romania,Czech Republic,Netherlands"  # Pro
 PVPN_ROTATE_COUNTRIES="${SERVER_COUNTRIES},France,Germany"  # Optional rotation order for arr.vpn switch (always includes SERVER_COUNTRIES)
 GLUETUN_CONTROL_PORT="8000"            # Host port that exposes the Gluetun control API
 ENABLE_LOCAL_DNS="1"                   # Enable the bundled dnsmasq container on LAN_IP
+DNS_DISTRIBUTION_MODE="router"         # router (DHCP Option 6) or per-device DNS settings
 UPSTREAM_DNS_1="1.1.1.1"               # First upstream resolver when local DNS is enabled
 UPSTREAM_DNS_2="1.0.0.1"               # Second upstream resolver when local DNS is enabled
 CADDY_LAN_CIDRS="127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"  # Clients allowed to skip Caddy auth

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -129,6 +129,7 @@ main() {
         ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS}" \
         LOCAL_DNS_SERVICE_ENABLED="${LOCAL_DNS_SERVICE_ENABLED}" \
         LOCALHOST_IP="${LOCALHOST_IP}" \
+        DNS_DISTRIBUTION_MODE="${DNS_DISTRIBUTION_MODE}" \
         GLUETUN_CONTROL_PORT="${GLUETUN_CONTROL_PORT}" \
         bash "${doctor_script}"; then
         warn "LAN diagnostics reported issues"

--- a/docs/LAN_DNS_SETUP.md
+++ b/docs/LAN_DNS_SETUP.md
@@ -1,10 +1,12 @@
-# Router setup for LAN DNS
+# LAN DNS setup guide
 
-Configure your home router so every device on the network uses your arrstack-mini host for LAN service lookups while still falling back to the public Internet when needed. These steps target beginners and use the default variables from `arrconf/userconf.defaults.sh`:
+Configure your home network so every device uses your arrstack-mini host for LAN service lookups while still falling back to the public Internet when needed. These steps target beginners and use the default variables from `arrconf/userconf.defaults.sh`:
 
 - `LAN_IP=192.168.1.50` – static IP of the Raspberry Pi running arrstack-mini.
 - `LAN_DOMAIN_SUFFIX=home.arpa` – RFC 8375 home-LAN domain used by the stack.
 - `DNS_DISTRIBUTION_MODE=router` – tells the installer and docs you are distributing DNS via router DHCP.
+
+If your router cannot advertise custom DNS servers, skip to [Unable to change router DNS?](#10-unable-to-change-router-dns) for per-device guidance.
 
 If your environment differs, substitute the equivalent values.
 

--- a/docs/ROUTER_DNS_SETUP.md
+++ b/docs/ROUTER_DNS_SETUP.md
@@ -1,0 +1,126 @@
+# Router setup for LAN DNS
+
+Configure your home router so every device on the network uses your arrstack-mini host for LAN service lookups while still falling back to the public Internet when needed. These steps target beginners and use the default variables from `arrconf/userconf.defaults.sh`:
+
+- `LAN_IP=192.168.1.50` – static IP of the Raspberry Pi running arrstack-mini.
+- `LAN_DOMAIN_SUFFIX=home.arpa` – RFC 8375 home-LAN domain used by the stack.
+- `DNS_DISTRIBUTION_MODE=router` – tells the installer and docs you are distributing DNS via router DHCP.
+
+If your environment differs, substitute the equivalent values.
+
+---
+
+## 1. Reserve your Pi's IP address
+
+1. Connect to your router's admin page (commonly `http://192.168.1.1` or the address listed on the router label).
+2. Sign in with the administrator credentials.
+3. Locate **Address Reservation**, **Static DHCP**, or **Client List**.
+4. Reserve the Raspberry Pi's MAC address to the IP in `LAN_IP` (default `192.168.1.50`).
+
+> **Why:** DHCP reservation ensures the Pi keeps the same LAN IP so clients never learn an outdated DNS address.
+
+---
+
+## 2. Open the DHCP / LAN settings page
+
+1. In the router menu, look for **LAN**, **Network**, or **Advanced** settings.
+2. Choose **DHCP Server**, **LAN Setup**, or similar wording. On TP-Link VX230v firmware the path is `Advanced → Network → LAN Settings → DHCP Server`.
+
+If your router exposes separate **WAN** and **LAN** DNS forms, only change the **LAN DHCP** section. Leave WAN DNS alone to preserve Internet connectivity.
+
+---
+
+## 3. Enter DNS servers in the correct order
+
+1. Set **Primary DNS** (sometimes labelled *DNS 1* or *Preferred DNS*) to your Pi's IP (`LAN_IP`).
+2. Set **Secondary DNS** (a.k.a. *DNS 2* or *Alternate DNS*) to a public resolver that already works in your home, for example Cloudflare `1.1.1.1` or Google `8.8.8.8`.
+3. Leave additional DNS boxes blank unless your ISP requires them.
+
+> **Why:** The router instructs clients to query the Pi first so hostnames like `qbittorrent.home.arpa` resolve locally. If the Pi is offline, devices automatically fall back to the public resolver and keep Internet access.
+
+---
+
+## 4. Clear any default domain suffix
+
+1. Find a field called **Default Domain**, **DNS Suffix**, or **Domain Name**.
+2. Leave it empty (recommended). Do **not** set `.local`; that suffix is reserved for mDNS and causes conflicts on macOS, iOS, and recent Windows versions.
+
+arrstack-mini already provides the safe suffix from `LAN_DOMAIN_SUFFIX` (`home.arpa` by default), so no router override is required.
+
+---
+
+## 5. Save and restart clients
+
+1. Click **Save** or **Apply** on the router page.
+2. Reboot or reconnect your laptops, phones, and TVs so they receive the refreshed DHCP lease containing the new DNS servers. Power-cycling the router is **not** necessary.
+
+---
+
+## 6. Verify from a client device
+
+After a device reconnects, open a terminal (Command Prompt on Windows, Terminal on macOS/Linux) and run:
+
+```bash
+nslookup qbittorrent.home.arpa
+```
+
+Check the output:
+
+- **Server** (or **Address**) should report your Pi's IP (for example `192.168.1.50`).
+- The answer should resolve to the same IP.
+
+If the command shows your ISP DNS or fails to resolve, renew the DHCP lease (`ipconfig /renew` on Windows, toggle Wi-Fi off/on on mobile) and ensure the DNS order in step 3 is correct.
+
+---
+
+## 7. TP-Link VX230v example
+
+TP-Link's ISP-customised firmware labels the inputs slightly differently. Use these mappings:
+
+1. Go to `Advanced → Network → LAN Settings`.
+2. Under **DHCP Server**, set:
+   - **Primary DNS** = `192.168.1.50` (your Pi).
+   - **Secondary DNS** = `1.1.1.1` (or your preferred public resolver).
+3. Leave **Domain Name** blank.
+4. Save the page and reconnect your clients.
+
+---
+
+## 8. Common pitfalls
+
+- **Primary/secondary reversed:** If a public resolver remains in the first slot, clients will never contact your Pi and LAN hostnames will fail.
+- **Android Private DNS enabled:** Set **Settings → Network & Internet → Internet → (gear icon) → Private DNS** to **Off** or **Automatic**; a hostname forces DNS-over-TLS and bypasses your LAN DNS.
+- **systemd-resolved still bound to port 53 on the Pi:** Run `./scripts/host-dns-setup.sh` on the host to disable the stub listener and write `/etc/resolv.conf` with your upstream DNS pair.
+- **Pi address not reserved:** Without DHCP reservation the Pi may obtain a new IP, breaking the mapping advertised to clients.
+
+---
+
+## 9. Link to `userconf`
+
+After confirming the router path works in your environment:
+
+1. Copy `arrconf/userconf.sh.example` to `arrconf/userconf.sh` if you have not already done so.
+2. Set the variables to match your network:
+
+   ```bash
+   LAN_IP=192.168.1.50
+   LAN_DOMAIN_SUFFIX=home.arpa
+   DNS_DISTRIBUTION_MODE=router
+   ```
+
+3. Rerun `./arrstack.sh` (or `./arrstack.sh --yes`) so the installer re-renders `.env` with the updated values.
+4. Optionally run `./scripts/doctor.sh` to confirm UDP/TCP DNS and the CA download succeed.
+
+---
+
+## 10. Unable to change router DNS?
+
+Some ISP routers lock down DHCP DNS. If you cannot change the settings above, fall back to per-device DNS:
+
+1. Set `DNS_DISTRIBUTION_MODE=per-device` in `arrconf/userconf.sh`.
+2. Manually configure each important client (Android/PC/TV) with DNS=`192.168.1.50` and keep Android Private DNS Off/Automatic.
+3. The rest of this guide still applies when you migrate to a configurable router.
+
+---
+
+Following these steps ensures LAN devices resolve `*.home.arpa` through arrstack-mini while retaining reliable Internet connectivity via the secondary resolver.

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -54,6 +54,7 @@ arrstack_setup_defaults() {
   : "${UPSTREAM_DNS_1:=1.1.1.1}"
   : "${UPSTREAM_DNS_2:=1.0.0.1}"
   : "${ENABLE_LOCAL_DNS:=1}"
+  : "${DNS_DISTRIBUTION_MODE:=router}"
   : "${SETUP_HOST_DNS:=0}"
   : "${REFRESH_ALIASES:=0}"
 

--- a/scripts/host-dns-setup.sh
+++ b/scripts/host-dns-setup.sh
@@ -25,6 +25,7 @@ LAN_IP="${LAN_IP:-192.168.1.50}"
 SUFFIX="${LAN_DOMAIN_SUFFIX:-home.arpa}" # RFC 8375 special-use domain
 FALLBACK1="${UPSTREAM_DNS_1:-1.1.1.1}"
 FALLBACK2="${UPSTREAM_DNS_2:-1.0.0.1}"
+MODE="${DNS_DISTRIBUTION_MODE:-router}"
 
 # ---- Paths & backups ----
 TS="$(date +%Y%m%d-%H%M%S)"
@@ -157,4 +158,8 @@ if [[ "${CURL_RC}" -ne 0 ]]; then
 fi
 
 echo "[done] Host DNS takeover complete. Backups in ${BACKUP_DIR}"
-echo "[hint] Router DHCP: set DNS server = ${LAN_IP} so LAN clients use local DNS automatically."
+if [[ "$MODE" == "per-device" ]]; then
+  echo "[hint] Per-device DNS: set DNS=${LAN_IP} on important clients and disable custom Private DNS on Android."
+else
+  echo "[hint] Router DHCP: set DNS server = ${LAN_IP} so LAN clients use local DNS automatically."
+fi

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -502,6 +502,10 @@ start_stack() {
     done
   fi
 
+  if ! sync_caddy_ca_public_copy --wait; then
+    warn "Caddy CA root certificate is not published yet; fetch http://ca.${ARR_DOMAIN_SUFFIX_CLEAN}/root.crt after Caddy issues it."
+  fi
+
   if ((qb_started)); then
     sync_qbt_password_from_logs
   fi


### PR DESCRIPTION
## Summary
- add DNS_DISTRIBUTION_MODE defaults/documentation so users can choose router-DHCP or per-device DNS flows and surface the choice in doctor + host helper messaging
- harden the local_dns service with --local-service, verify TCP lookups, and extend the doctor to check port 53 conflicts and CA bootstrap
- expose only Caddy's public root certificate via a new ca-pub mount, keep HTTP available for bootstrap, and sync the file automatically after start

## Testing
- shellcheck arrconf/userconf.defaults.sh arrconf/userconf.sh.example scripts/defaults.sh scripts/files.sh scripts/services.sh scripts/doctor.sh scripts/host-dns-setup.sh arrstack.sh
- ./arrstack.sh --help


------
https://chatgpt.com/codex/tasks/task_e_68d3157f8b548329bfa2af1f5135937f