### PR TITLE
fix(userconf): align overrides with defaults load order

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Default configuration for ARR Stack
-# Override these in arrconf/userconf.sh (git-ignored)
+# This file is sourced *before* arrconf/userconf.sh.
+# Keep assignments idempotent and avoid relying on side effects so overrides
+# behave predictably when userconf.sh runs afterwards.
+# Override these in arrconf/userconf.sh (git-ignored).
 
 # Guard helpers for shells that source these defaults alongside other scripts
 if ! declare -f arrstack_var_is_readonly >/dev/null 2>&1; then
@@ -29,7 +32,7 @@ ARR_ENV_FILE="${ARR_ENV_FILE:-${ARR_STACK_DIR}/.env}"
 ARR_LOG_DIR="${ARR_LOG_DIR:-${ARR_STACK_DIR}/logs}"
 ARR_INSTALL_LOG="${ARR_INSTALL_LOG:-${ARR_LOG_DIR}/arrstack-install.log}"
 ARR_DOCKER_DIR="${ARR_DOCKER_DIR:-${ARR_BASE}/docker-data}"
-ARRCONF_DIR="${ARRCONF_DIR:-${PWD}/arrconf}"
+ARRCONF_DIR="${ARRCONF_DIR:-${REPO_ROOT:-${PWD}}/arrconf}"
 
 # File/dir permissions (strict keeps secrets 600/700, collaborative loosens group access)
 if ! arrstack_var_is_readonly ARR_PERMISSION_PROFILE; then

--- a/arrconf/userconf.sh.example
+++ b/arrconf/userconf.sh.example
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
-# Copy to arrconf/userconf.sh and edit as needed, overrides defaults.
+# Copy to arrconf/userconf.sh and edit as needed. Values here override the
+# defaults from arrconf/userconf.defaults.sh, which loads first.
 
 # --- Stack paths ---
 ARR_BASE="${HOME}/srv"                 # Root directory for generated stack files
 ARR_STACK_DIR="${ARR_BASE}/arrstack"  # Location for docker-compose.yml, scripts, and aliases
 ARR_ENV_FILE="${ARR_STACK_DIR}/.env"  # Path to the generated .env secrets file
 ARR_DOCKER_DIR="${ARR_BASE}/docker-data"  # Docker volumes and persistent data storage
-# ARRCONF_DIR="${PWD}/arrconf"         # Uncomment to move Proton credentials outside the repo tree
+# ARRCONF_DIR="${HOME}/.config/arrstack"  # Optional: relocate Proton creds outside the repo
 
 # --- Permissions ---
 ARR_PERMISSION_PROFILE="strict"        # strict keeps secrets 600/700, collaborative loosens group access
@@ -44,7 +45,7 @@ EXPOSE_DIRECT_PORTS="0"                # Publish raw app ports on the LAN alongs
 QBT_USER="admin"                       # Initial qBittorrent username (change after first login)
 QBT_PASS="adminadmin"                  # Initial qBittorrent password (update immediately after install)
 GLUETUN_API_KEY=""                     # Pre-seed a Gluetun API key or leave empty to auto-generate
-# QBT_DOCKER_MODS="ghcr.io/vuetorrent/vuetorrent-lsio-mod:latest"  # Alternate qBittorrent WebUI mod image
+QBT_DOCKER_MODS="ghcr.io/vuetorrent/vuetorrent-lsio-mod:latest"  # Vuetorrent WebUI mod (set empty to disable)
 QBT_AUTH_WHITELIST="127.0.0.1/8,::1/128"  # CIDRs allowed to bypass the qBittorrent login prompt
 CADDY_BASIC_AUTH_USER="user"           # Username clients outside CADDY_LAN_CIDRS must use
 CADDY_BASIC_AUTH_HASH=""               # Bcrypt hash for the Basic Auth password (regen when empty)


### PR DESCRIPTION
## Summary
- document how arrconf/userconf defaults are sourced and keep assignments side-effect free
- base the default ARRCONF_DIR on REPO_ROOT with a fallback for standalone sourcing
- refresh the userconf.sh example to reflect the new defaults and Vuetorrent mod behaviour

## Testing
- shellcheck arrconf/userconf.defaults.sh arrconf/userconf.sh.example
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d37cb9e2648329b585c5cfc65746da