### PR TITLE
feat: harden compose preflight and service startup

### DIFF
--- a/arrstack.sh
+++ b/arrstack.sh
@@ -114,10 +114,12 @@ main() {
   generate_api_key
   write_env
   write_compose
+  preflight_compose_interpolation
   validate_compose_or_die
   write_gluetun_control_assets
   ensure_caddy_auth
   write_caddy_assets
+  validate_caddy_config
   sync_gluetun_library
   write_qbt_helper_script
   write_qbt_config

--- a/docs/https-and-ca.md
+++ b/docs/https-and-ca.md
@@ -28,6 +28,8 @@ Caddy creates a private certificate authority (CA) for `*.home.arpa`. Importing 
 
 On Debian or Ubuntu, run `./scripts/install-caddy-ca.sh` to copy the certificate into `/usr/local/share/ca-certificates` and refresh the trust store automatically (the script escalates with `sudo`).【F:scripts/install-caddy-ca.sh†L1-L118】 Use `./scripts/export-caddy-ca.sh ~/Downloads/arrstack-root.crt` when you just need to copy the public root certificate to another machine with the correct permissions.【F:scripts/export-caddy-ca.sh†L1-L35】
 
+During installation the stack now validates the generated Caddyfile with `caddy validate` and waits for Caddy’s healthcheck before starting the downstream web UIs, which prevents first-boot certificate races.【F:scripts/services.sh†L72-L117】【F:scripts/files.sh†L374-L612】
+
 ## Verify
 Open a browser and visit:
 ```

--- a/docs/script-reference.md
+++ b/docs/script-reference.md
@@ -39,6 +39,7 @@ Run these helpers individually when you need to make targeted adjustments:
 | `scripts/export-caddy-ca.sh` | Copy the Caddy CA to another device | Writes the public `root.crt` to a path of your choice with safe permissions so you can import it manually.【F:scripts/export-caddy-ca.sh†L1-L35】 |
 | `scripts/qbt-helper.sh` | View or reset qBittorrent WebUI access | Shows current URLs, reads temporary passwords from logs, resets the PBKDF2 hash, or whitelists your LAN subnet.【F:scripts/qbt-helper.sh†L1-L153】 |
 | `scripts/fix-versions.sh` | Docker Hub removed a pinned tag | Backs up `.env`, checks pinned LinuxServer images, and swaps to `:latest` when a manifest goes missing.【F:scripts/fix-versions.sh†L1-L55】 |
+| `scripts/dev/find-unescaped-dollar.sh` | Compose reports `variable is not set` warnings | Scans a Compose file for `${...}` tokens, compares them to `.env`/defaults, and prints context for any unresolved entries so you can escape literal `$` values or define the variable.【F:scripts/dev/find-unescaped-dollar.sh†L1-L99】 |
 | `scripts/aliases.sh` (`arrstack.sh --refresh-aliases`) | Helper aliases look outdated | Regenerates `.arraliases`, installs convenient shell aliases, and drops `diagnose-vpn.sh` alongside the stack.【F:scripts/aliases.sh†L1-L120】 |
 | `scripts/gluetun.sh` | Reference for custom automation | Provides reusable functions to call the Gluetun control API, parse public IP info, and read the forwarded port without writing your own curl logic.【F:scripts/gluetun.sh†L1-L165】【F:scripts/gluetun.sh†L167-L229】 |
 

--- a/scripts/dev/find-unescaped-dollar.sh
+++ b/scripts/dev/find-unescaped-dollar.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/find-unescaped-dollar.sh [COMPOSE_FILE]
+
+Scan a docker-compose.yml for environment interpolation tokens (e.g. ${VAR})
+and report any that do not have a matching definition in the generated .env file
+or the repository defaults.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+compose_file="${1:-}";
+if [[ -z "$compose_file" ]]; then
+  if [[ -n "${ARR_STACK_DIR:-}" ]]; then
+    compose_file="${ARR_STACK_DIR}/docker-compose.yml"
+  else
+    compose_file="docker-compose.yml"
+  fi
+fi
+
+if [[ ! -f "$compose_file" ]]; then
+  echo "compose file not found: $compose_file" >&2
+  exit 1
+fi
+
+compose_dir="$(cd "$(dirname "$compose_file")" && pwd)"
+
+collect_keys() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    return
+  fi
+  awk -F= '/^[A-Za-z_][A-Za-z0-9_]*=/ {print $1}' "$file"
+}
+
+declare -A allow_map=()
+
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  allow_map["$key"]=1
+done < <(collect_keys "${compose_dir}/.env" 2>/dev/null || true)
+
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  allow_map["$key"]=1
+done < <(collect_keys "${REPO_ROOT}/.env.example" 2>/dev/null || true)
+
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  allow_map["$key"]=1
+done < <(collect_keys "${REPO_ROOT}/arrconf/userconf.defaults.sh" 2>/dev/null || true)
+
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  allow_map["$key"]=1
+done < <(collect_keys "${REPO_ROOT}/arrconf/userconf.sh.example" 2>/dev/null || true)
+
+# Common compose internals we intentionally reference
+for key in COMPOSE_PROJECT_NAME DOCKER_CLIENT_TIMEOUT DOCKER_HOST; do
+  allow_map["$key"]=1
+done
+
+mapfile -t tokens < <(grep -oE '\$\{[^}]+\}' "$compose_file" | sed 's/^\${//' | sed 's/}$//' | sort -u)
+
+if ((${#tokens[@]} == 0)); then
+  echo "No interpolation tokens detected in ${compose_file}."
+  exit 0
+fi
+
+declare -a suspects=()
+for token in "${tokens[@]}"; do
+  if [[ -z "${allow_map[$token]+x}" ]]; then
+    suspects+=("$token")
+  fi
+done
+
+if ((${#suspects[@]} == 0)); then
+  echo "All interpolation tokens are accounted for."
+  exit 0
+fi
+
+echo "== Tokens without matching definitions =="
+printf '%s\n' "${suspects[@]}"
+
+echo
+for token in "${suspects[@]}"; do
+  echo "-- \${${token}} --"
+  while IFS=: read -r line _; do
+    start=$((line > 2 ? line - 2 : 1))
+    end=$((line + 2))
+    nl -ba "$compose_file" | sed -n "${start},${end}p"
+    echo
+  done < <(grep -nF "\${${token}}" "$compose_file" || true)
+done

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -39,7 +39,9 @@ run_one_time_migrations() {
       fixed_value="${existing_unescaped%+pmp}+pmp"
       if [[ "$fixed_value" != "$existing_unescaped" ]]; then
         ensure_env_backup
-        sed_value="$(escape_sed_replacement "$fixed_value")"
+        local compose_value
+        compose_value="$(escape_env_value_for_compose "$fixed_value")"
+        sed_value="$(escape_sed_replacement "$compose_value")"
         portable_sed "s|^OPENVPN_USER=.*$|OPENVPN_USER=${sed_value}|" "${ARR_ENV_FILE}"
         warn "OPENVPN_USER was missing '+pmp'; updated automatically in ${ARR_ENV_FILE}"
       fi
@@ -51,7 +53,9 @@ run_one_time_migrations() {
       existing_unescaped="$(unescape_env_value_from_compose "$existing_value")"
       if [[ "$existing_value" != "$existing_unescaped" ]]; then
         ensure_env_backup
-        sed_value="$(escape_sed_replacement "$existing_unescaped")"
+        local compose_hash
+        compose_hash="$(escape_env_value_for_compose "$existing_unescaped")"
+        sed_value="$(escape_sed_replacement "$compose_hash")"
         portable_sed "s|^CADDY_BASIC_AUTH_HASH=.*$|CADDY_BASIC_AUTH_HASH=${sed_value}|" "${ARR_ENV_FILE}"
         warn "Normalized CADDY_BASIC_AUTH_HASH format for Docker Compose compatibility"
       fi


### PR DESCRIPTION
## Summary
- add a compose interpolation preflight step and validate the generated Caddyfile before starting the stack
- escape `$` values when writing .env files and ship a helper script to locate unresolved `${VAR}` tokens in docker-compose.yml
- tighten port-53 checks to use exact ss/lsof filters and gate Caddy/arr services on local DNS and Caddy healthchecks

## Testing
- `shellcheck arrstack.sh scripts/common.sh scripts/migrations.sh scripts/files.sh scripts/services.sh scripts/doctor.sh scripts/host-dns-setup.sh scripts/dev/find-unescaped-dollar.sh` *(reports existing style/info warnings)*
- `./arrstack.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68d40d2df9dc8329b743aec3d418907c