### PR TITLE
feat(network): default lan access to ip ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,36 +1,63 @@
-# Core runtime
+# Core settings
 VPN_TYPE=openvpn
+PUID=1000
+PGID=1000
 TIMEZONE=Australia/Sydney
 LAN_IP=0.0.0.0
 LOCALHOST_IP=127.0.0.1
-SERVER_COUNTRIES=Netherlands,Germany,Switzerland
+EXPOSE_DIRECT_PORTS=1
+ENABLE_CADDY=0
 
-# Container user/group
-PUID=1000
-PGID=1000
+# Local DNS (disabled by default)
+LAN_DOMAIN_SUFFIX=home.arpa
+ENABLE_LOCAL_DNS=0
+DNS_DISTRIBUTION_MODE=router
+UPSTREAM_DNS_1=1.1.1.1
+UPSTREAM_DNS_2=1.0.0.1
+DNS_HOST_ENTRY=HOST_IP
 
-# Loopback & control (fixed by default, but configurable)
-GLUETUN_LOOPBACK_HOST=127.0.0.1
-# Ports allowed from the host into the Gluetun container (comma-separated).
-# Adjust to your stack; defaults cover control API + common *arr UIs.
-# Tip: set to "" to block LAN input and rely solely on VPN-forwarded ports.
-GLUETUN_LAN_INPUT_PORTS=8000,8080,8989,7878,9696,6767,8191
-GLUETUN_CONTROL_HOST=127.0.0.1
-GLUETUN_CONTROL_PORT=8000
+# ProtonVPN credentials
+OPENVPN_USER=
+OPENVPN_PASSWORD=
+
+# Derived values
+OPENVPN_USER_ENFORCED=
+COMPOSE_PROFILES=ipdirect
+
+# Gluetun settings
+VPN_SERVICE_PROVIDER=protonvpn
 GLUETUN_API_KEY=replace-with-generated-key
+GLUETUN_CONTROL_PORT=8000
+SERVER_COUNTRIES=Netherlands
+GLUETUN_FIREWALL_INPUT_PORTS=8080,8989,7878,9696,6767,8191
+GLUETUN_FIREWALL_OUTBOUND_SUBNETS=192.168.0.0/16,10.0.0.0/8,172.16.0.0/12
 
-# Web UI ports
-QBT_HTTP_PORT_CONTAINER=8080
-QBT_HTTP_PORT_HOST=8081
+# Service ports (exposed on the LAN IP)
+QBT_HTTP_PORT_HOST=8080
 SONARR_PORT=8989
 RADARR_PORT=7878
 PROWLARR_PORT=9696
 BAZARR_PORT=6767
 FLARESOLVERR_PORT=8191
 
-# qBittorrent credentials (update after first login)
+# qBittorrent credentials (change after first login)
 QBT_USER=admin
 QBT_PASS=adminadmin
+QBT_DOCKER_MODS=ghcr.io/vuetorrent/vuetorrent-lsio-mod:latest
+QBT_AUTH_WHITELIST=127.0.0.1/32,::1/128
+
+# Reverse proxy defaults (proxy profile)
+CADDY_DOMAIN_SUFFIX=home.arpa
+CADDY_LAN_CIDRS=127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+CADDY_BASIC_AUTH_USER=user
+CADDY_BASIC_AUTH_HASH=
+
+# Paths
+ARR_DOCKER_DIR=${PWD}/docker-data
+DOWNLOADS_DIR=${PWD}/downloads
+COMPLETED_DIR=${PWD}/completed
+TV_DIR=${PWD}/media/tv
+MOVIES_DIR=${PWD}/media/movies
 
 # Images
 GLUETUN_IMAGE=qmcgaw/gluetun:v3.39.1
@@ -40,17 +67,4 @@ RADARR_IMAGE=lscr.io/linuxserver/radarr:5.27.5.10198-ls283
 PROWLARR_IMAGE=lscr.io/linuxserver/prowlarr:latest
 BAZARR_IMAGE=lscr.io/linuxserver/bazarr:latest
 FLARESOLVERR_IMAGE=ghcr.io/flaresolverr/flaresolverr:v3.3.21
-
-# Paths
-ARR_DOCKER_DIR=${PWD}/docker-data
-ARRCONF_DIR=${PWD}/arrconf
-DOWNLOADS_DIR=${PWD}/downloads
-COMPLETED_DIR=${PWD}/completed
-MEDIA_DIR=${PWD}/media
-TV_DIR=${MEDIA_DIR}/tv
-MOVIES_DIR=${MEDIA_DIR}/movies
-
-# Gluetun firewall & health
-GLUETUN_FIREWALL_OUTBOUND_SUBNETS=192.168.0.0/16,10.0.0.0/8
-GLUETUN_VPN_INPUT_PORTS=8081,8989,7878,9696,6767,8191
-GLUETUN_HEALTH_TARGET_ADDRESS=1.1.1.1:443
+CADDY_IMAGE=caddy:2.8.4

--- a/README.md
+++ b/README.md
@@ -38,19 +38,21 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g
    ```
    The script installs dependencies if needed, renders `.env`, and launches the stack with Docker Compose.
    Compose reads `.env` automatically per [Docker’s env-file guidance](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-env-file).
-6. **On Debian Bookworm, free port 53 for dnsmasq.** `systemd-resolved` often owns `127.0.0.53:53` on fresh installs and blocks the `local_dns` container. The helper stops and disables it only when necessary, writes an idempotent `/etc/resolv.conf`, and then starts `local_dns`.
-   ```bash
-   ./scripts/host-dns-setup.sh
-   ```
-   Re-run the helper whenever you change LAN IPs or DNS upstreams; it safely records backups each time.
-7. **Choose how clients learn the DNS server.** Follow [LAN DNS & network pre-start](docs/lan-dns-network-setup.md) to delegate DNS through your router (Option 6 / RDNSS) or evaluate per-device overrides.
-8. **Open qBittorrent to confirm access.** Visit `https://qbittorrent.home.arpa` (replace the suffix if you changed it) and change the default password.
+6. **Open the WebUIs directly by IP.** As soon as the installer finishes, browse to each service using your Pi’s LAN IP (example `192.168.1.50`):
+   - `http://192.168.1.50:8080` (qBittorrent)
+   - `http://192.168.1.50:8989` (Sonarr)
+   - `http://192.168.1.50:7878` (Radarr)
+   - `http://192.168.1.50:9696` (Prowlarr)
+   - `http://192.168.1.50:6767` (Bazarr)
+   - `http://192.168.1.50:8191` (FlareSolverr health page)
+   The default qBittorrent credentials are `admin` / `adminadmin` — change them immediately.
+7. **(Optional) Enable extras later.** Set `ENABLE_CADDY=1` for HTTPS reverse proxying or `ENABLE_LOCAL_DNS=1` for dnsmasq, then rerun `./arrstack.sh`. The defaults keep both disabled so IP:PORT access works everywhere without touching your router.
 
 **Verify:**
 ```bash
-dig @192.168.1.50 qbittorrent.home.arpa
+curl -I http://192.168.1.50:8080
 ```
-You should see the Pi’s IP in the answer. If not, revisit steps 6–7.
+You should see an HTTP 200/302 response. If not, re-run the installer and confirm the LAN IP detection.
 
 ## Useful commands
 - `./arrstack.sh --rotate-api-key --yes` regenerates the Gluetun API key and writes it back to `.env`.

--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -57,7 +57,8 @@ PGID="${PGID:-$(id -g)}"
 TIMEZONE="${TIMEZONE:-Australia/Sydney}"
 LAN_IP="${LAN_IP:-0.0.0.0}"
 LOCALHOST_IP="${LOCALHOST_IP:-127.0.0.1}"
-SERVER_COUNTRIES="${SERVER_COUNTRIES:-Switzerland,Iceland,Romania,Czech Republic,Netherlands}"
+SERVER_COUNTRIES="${SERVER_COUNTRIES:-Netherlands}"
+# SERVER_NAMES=""  # Optionally pin Proton server hostnames if PF keeps returning 0 (comma-separated list)
 PVPN_ROTATE_COUNTRIES="${PVPN_ROTATE_COUNTRIES:-${SERVER_COUNTRIES}}"
 
 # Domain suffix used by Caddy hostnames (default to RFC 8375 recommendation)
@@ -68,7 +69,8 @@ UPSTREAM_DNS_1="${UPSTREAM_DNS_1:-1.1.1.1}"
 UPSTREAM_DNS_2="${UPSTREAM_DNS_2:-1.0.0.1}"
 
 # Enable internal local DNS resolver service
-ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS:-1}"
+ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS:-0}"
+ENABLE_CADDY="${ENABLE_CADDY:-0}"
 
 # How LAN clients learn the resolver address
 #   router     – configure DHCP Option 6 on your router to ${LAN_IP}
@@ -92,7 +94,7 @@ BAZARR_PORT="${BAZARR_PORT:-6767}"
 FLARESOLVERR_PORT="${FLARESOLVERR_PORT:-8191}"
 
 # Expose application ports directly on the host alongside Caddy's reverse proxy
-EXPOSE_DIRECT_PORTS="${EXPOSE_DIRECT_PORTS:-0}"
+EXPOSE_DIRECT_PORTS="${EXPOSE_DIRECT_PORTS:-1}"
 
 # qBittorrent credentials (override after first login)
 QBT_USER="${QBT_USER:-admin}"

--- a/arrconf/userconf.sh.example
+++ b/arrconf/userconf.sh.example
@@ -27,19 +27,21 @@ PGID="$(id -g)"                        # Numeric group ID with write access to m
 TIMEZONE="Australia/Sydney"            # Timezone for container logs and schedules
 
 # --- Networking ---
-LAN_IP=""                              # Bind services to one LAN IP (leave blank to listen on all)
+LAN_IP=""                              # Bind services to one LAN IP (leave blank to auto-detect during install)
 LOCALHOST_IP="127.0.0.1"               # Loopback used by the Gluetun control API
 LAN_DOMAIN_SUFFIX="home.arpa"          # Suffix appended to service hostnames (RFC 8375 default)
 CADDY_DOMAIN_SUFFIX="${LAN_DOMAIN_SUFFIX}"  # Override Caddy hostname suffix independently of LAN DNS
-SERVER_COUNTRIES="Switzerland,Iceland,Romania,Czech Republic,Netherlands"  # ProtonVPN exit country list
-PVPN_ROTATE_COUNTRIES="${SERVER_COUNTRIES},France,Germany"  # Optional rotation order for arr.vpn switch (always includes SERVER_COUNTRIES)
+SERVER_COUNTRIES="Netherlands"              # ProtonVPN exit country list (single PF-capable country by default)
+# SERVER_NAMES=""                          # Optionally pin Proton server hostnames (comma-separated) if PF stays at 0
+PVPN_ROTATE_COUNTRIES="${SERVER_COUNTRIES}"  # Optional rotation order for arr.vpn switch (always includes SERVER_COUNTRIES)
 GLUETUN_CONTROL_PORT="8000"            # Host port that exposes the Gluetun control API
-ENABLE_LOCAL_DNS="1"                   # Enable the bundled dnsmasq container on LAN_IP
+ENABLE_LOCAL_DNS="0"                   # Advanced: enable the optional dnsmasq container (localdns profile)
+ENABLE_CADDY="0"                       # Advanced: enable the optional Caddy reverse proxy (proxy profile)
 DNS_DISTRIBUTION_MODE="router"         # router (DHCP Option 6) or per-device DNS settings
 UPSTREAM_DNS_1="1.1.1.1"               # First upstream resolver when local DNS is enabled
 UPSTREAM_DNS_2="1.0.0.1"               # Second upstream resolver when local DNS is enabled
 CADDY_LAN_CIDRS="127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"  # Clients allowed to skip Caddy auth
-EXPOSE_DIRECT_PORTS="0"                # Publish raw app ports on the LAN alongside Caddy (troubleshooting aid)
+EXPOSE_DIRECT_PORTS="1"                # Default LAN access: expose WebUIs on http://${LAN_IP}:PORT (ipdirect profile)
 
 # --- Credentials ---
 QBT_USER="admin"                       # Initial qBittorrent username (change after first login)

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,7 +20,7 @@ Clear defaults keep the stack reproducible. Changing only what you need reduces 
 - **`DNS_DISTRIBUTION_MODE`** – choose `router` or `per-device` (see [LAN DNS & network pre-start](lan-dns-network-setup.md)).
 - **`UPSTREAM_DNS_1` / `UPSTREAM_DNS_2`** – public resolvers used when the Pi forwards queries. Defaults work for most homes.
 - **`GLUETUN_CONTROL_PORT`** – keep `8000` unless another local service uses it.
-- **`EXPOSE_DIRECT_PORTS`** – leave at `0` so Caddy is the only LAN entry point. Set `1` only if you need direct ports for testing.
+- **`EXPOSE_DIRECT_PORTS`** – defaults to `1` so every WebUI is reachable at `http://LAN_IP:PORT`. Set to `0` if you want Caddy to be the sole LAN entry point.
 
 ### Credentials and security
 - **`QBT_USER` / `QBT_PASS`** – update after first login to qBittorrent. Keep `.env` in sync.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -11,7 +11,7 @@ The deployment holds VPN credentials, API keys, and a local certificate authorit
 - **Lock down secrets.** Leave the default permission profile at `strict` so `.env`, `arrconf/proton.auth`, and Caddy credentials stay readable only by your user.
 - **Do not publish the PKI directory.** Serve only `caddy/ca-pub/root.crt`. Never map `caddy/pki` or other certificate folders outside the stack.
 - **Rotate passwords.** Change qBittorrent credentials after first login, then update `.env` to match. Run `./arrstack.sh --rotate-caddy-auth` when sharing access outside your LAN.
-- **Keep VPN egress inside Gluetun.** Do not expose application containers directly unless you understand the risk. Leave `EXPOSE_DIRECT_PORTS=0` and rely on Caddy for LAN access.
+- **Keep LAN exposure limited.** Direct IP ports are enabled by default for simplicity—set `LAN_IP` to your private address and never forward these ports through your router. Enable the Caddy proxy only when you need HTTPS or external access.
 - **Use basic auth remotely.** If you forward ports through your router, keep the generated Caddy basic auth credentials secret and rotate them regularly.
 - **Check commits for personal data.** Before pushing changes, run:
   ```bash
@@ -23,9 +23,9 @@ The deployment holds VPN credentials, API keys, and a local certificate authorit
 ## Verify
 Periodically confirm only the expected ports are open on the Pi:
 ```bash
-sudo ss -tulpn | grep -E ':80|:443|:53'
+sudo ss -tulpn | grep -E ':8080|:8989|:7878|:9696|:6767|:8191|:80|:443|:53'
 ```
-Expect to see Caddy on 80/443 and dnsmasq on 53 bound to `192.168.1.50`. Anything else should be reviewed.
+Expect to see the *arr ports bound to your LAN IP, with 80/443 present only when Caddy is enabled and 53 only when local DNS is active. Anything else should be reviewed.
 
 ## See also
 - [Config reference](config.md)

--- a/docs/services.md
+++ b/docs/services.md
@@ -10,22 +10,22 @@ Knowing the entry points makes first verification easy and helps you decide whic
 ## Do
 | Service | Default LAN URL | Credentials at first boot | Change ports in |
 | --- | --- | --- | --- |
-| [qBittorrent](https://www.qbittorrent.org/) | `https://qbittorrent.home.arpa` | Uses the username/password stored in `.env` (`QBT_USER`/`QBT_PASS`). Rotate them on first login under **Tools → Options → Web UI**. | `.env` (`QBT_WEBUI_PORT`) or `arrconf/userconf.sh` overrides |
-| [Sonarr](https://sonarr.tv/) | `https://sonarr.home.arpa` | Default login disabled; set your own under **Settings → General → Security**. | `.env` (`SONARR_PORT`) |
-| [Radarr](https://radarr.video/) | `https://radarr.home.arpa` | No password by default; enable authentication in **Settings → General**. | `.env` (`RADARR_PORT`) |
-| [Prowlarr](https://prowlarr.com/) | `https://prowlarr.home.arpa` | Prompts for setup wizard; create an admin account during onboarding. | `.env` (`PROWLARR_PORT`) |
-| [Bazarr](https://www.bazarr.media/) | `https://bazarr.home.arpa` | Set a password at **Settings → General → Authentication**. | `.env` (`BAZARR_PORT`) |
-| [FlareSolverr](https://flaresolverr.com/) | `http://flaresolverr.home.arpa` | No UI; used by other services. Protect access with Caddy basic auth when exposing remotely. | `.env` (`FLARESOLVERR_PORT`) |
-| [Gluetun control API](https://github.com/qdm12/gluetun) | `http://gluetun.home.arpa:8000` (LAN only) | Requires the API key stored in `.env` (`GLUETUN_API_KEY`). | `.env` (`GLUETUN_CONTROL_PORT`) |
-| [Caddy status page](https://caddyserver.com/) | `https://caddy.home.arpa` | LAN clients bypass basic auth. Regenerate remote credentials with `./arrstack.sh --rotate-caddy-auth`. | `.env` (`CADDY_HTTP_PORT`, `CADDY_HTTPS_PORT`) |
+| [qBittorrent](https://www.qbittorrent.org/) | `http://<LAN_IP>:8080` | Uses the username/password stored in `.env` (`QBT_USER`/`QBT_PASS`). Rotate them on first login under **Tools → Options → Web UI**. | `.env` (`QBT_HTTP_PORT_HOST`) or `arrconf/userconf.sh` overrides |
+| [Sonarr](https://sonarr.tv/) | `http://<LAN_IP>:8989` | Default login disabled; set your own under **Settings → General → Security**. | `.env` (`SONARR_PORT`) |
+| [Radarr](https://radarr.video/) | `http://<LAN_IP>:7878` | No password by default; enable authentication in **Settings → General**. | `.env` (`RADARR_PORT`) |
+| [Prowlarr](https://prowlarr.com/) | `http://<LAN_IP>:9696` | Prompts for setup wizard; create an admin account during onboarding. | `.env` (`PROWLARR_PORT`) |
+| [Bazarr](https://www.bazarr.media/) | `http://<LAN_IP>:6767` | Set a password at **Settings → General → Authentication**. | `.env` (`BAZARR_PORT`) |
+| [FlareSolverr](https://flaresolverr.com/) | `http://<LAN_IP>:8191` | No UI; used by other services. Protect access when exposing remotely. | `.env` (`FLARESOLVERR_PORT`) |
+| [Gluetun control API](https://github.com/qdm12/gluetun) | `http://127.0.0.1:8000` (host loopback) | Requires the API key stored in `.env` (`GLUETUN_API_KEY`). | `.env` (`GLUETUN_CONTROL_PORT`) |
+| [Caddy status page](https://caddyserver.com/) *(optional)* | `https://caddy.<suffix>` (if `ENABLE_CADDY=1`) | LAN clients bypass basic auth. Regenerate remote credentials with `./arrstack.sh --rotate-caddy-auth`. | `.env` (`CADDY_DOMAIN_SUFFIX`) |
 
 Notes:
-- The URLs assume `LAN_DOMAIN_SUFFIX=home.arpa`. Replace the suffix if you customised it.
-- Local DNS must point clients at the Pi (see [LAN DNS & network pre-start](lan-dns-network-setup.md)). Without DNS, use `https://<LAN_IP>` with the exact port numbers from `.env`.
+- Replace `<LAN_IP>` with the address detected by the installer (example `192.168.1.50`).
+- If you enable Caddy and local DNS later, hostnames such as `https://qbittorrent.<suffix>` become available in addition to the raw IP:PORT URLs.
 - Use [Config reference](config.md) to locate additional overrides and credentials.
 
 ## Verify
-After `docker compose up -d`, open `https://qbittorrent.home.arpa` in a browser. If it loads without certificate warnings, HTTPS and DNS are set up correctly.
+After `docker compose up -d`, open `http://<LAN_IP>:8080` in a browser to confirm qBittorrent is reachable. Enable the proxy profile later if you need HTTPS hostnames.
 
 ## See also
 - [Quick start](../README.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ Most issues come from DNS conflicts, VPN startup delays, or missing certificates
 
 ## Do
 ### Symptom: `ERR_NAME_NOT_RESOLVED`
-- **Fix:** Ensure clients use the Pi as their first DNS server. Follow [LAN DNS & network pre-start](lan-dns-network-setup.md) and reboot the device or renew its DHCP lease.
+- **Fix:** (Only applies if you enabled the optional local DNS profile.) Ensure clients use the Pi as their first DNS server. Follow [LAN DNS & network pre-start](lan-dns-network-setup.md) and reboot the device or renew its DHCP lease.
 - **Verify:**
   ```bash
   nslookup qbittorrent.home.arpa
@@ -32,7 +32,7 @@ Most issues come from DNS conflicts, VPN startup delays, or missing certificates
 - **Verify:** Re-run `nslookup` or `dig` from the device and confirm the server is the Pi.
 
 ### Symptom: Browser warns about HTTPS certificate
-- **Fix:** Import `root.crt` using [Local HTTPS and CA trust](https-and-ca.md). Make sure you fetched it from `http://ca.home.arpa/root.crt`.
+- **Fix:** (Only when `ENABLE_CADDY=1`.) Import `root.crt` using [Local HTTPS and CA trust](https-and-ca.md). Make sure you fetched it from `http://ca.home.arpa/root.crt`.
 - **Verify:** Visit `https://qbittorrent.home.arpa` and confirm the lock icon is present.
 
 ### Symptom: Containers stuck in `starting`
@@ -86,7 +86,7 @@ If you edited configuration files, follow up with:
 ```bash
 ./arrstack.sh --yes
 ```
-This regenerates `.env` and restarts containers. Review the summary, then browse to `https://qbittorrent.home.arpa` to confirm everything loads.
+This regenerates `.env` and restarts containers. Review the summary, then browse to `http://<LAN_IP>:8080` to confirm everything loads.
 
 ## See also
 - [LAN DNS & network pre-start](lan-dns-network-setup.md)

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -31,7 +31,7 @@ arrstack_setup_defaults() {
   ASSUME_YES="${ASSUME_YES:-0}"
   FORCE_ROTATE_API_KEY="${FORCE_ROTATE_API_KEY:-0}"
   LOCALHOST_IP="${LOCALHOST_IP:-127.0.0.1}"
-  SERVER_COUNTRIES="${SERVER_COUNTRIES:-Switzerland,Iceland,Romania,Czech Republic,Netherlands}"
+  SERVER_COUNTRIES="${SERVER_COUNTRIES:-Netherlands}"
 
   : "${PUID:=$(id -u)}"
   : "${PGID:=$(id -g)}"
@@ -53,7 +53,8 @@ arrstack_setup_defaults() {
 
   : "${UPSTREAM_DNS_1:=1.1.1.1}"
   : "${UPSTREAM_DNS_2:=1.0.0.1}"
-  : "${ENABLE_LOCAL_DNS:=1}"
+  : "${ENABLE_LOCAL_DNS:=0}"
+  : "${ENABLE_CADDY:=0}"
   : "${DNS_DISTRIBUTION_MODE:=router}"
   : "${SETUP_HOST_DNS:=0}"
   : "${REFRESH_ALIASES:=0}"
@@ -79,7 +80,7 @@ arrstack_setup_defaults() {
   : "${PROWLARR_IMAGE:=lscr.io/linuxserver/prowlarr:latest}"
   : "${BAZARR_IMAGE:=lscr.io/linuxserver/bazarr:latest}"
   : "${FLARESOLVERR_IMAGE:=ghcr.io/flaresolverr/flaresolverr:v3.3.21}"
-  : "${EXPOSE_DIRECT_PORTS:=0}"
+  : "${EXPOSE_DIRECT_PORTS:=1}"
 
   if [[ -n "${CADDY_DOMAIN_SUFFIX:-}" ]]; then
     CADDY_DOMAIN_SUFFIX="${CADDY_DOMAIN_SUFFIX#.}"

--- a/scripts/dns.sh
+++ b/scripts/dns.sh
@@ -9,7 +9,7 @@ configure_local_dns_entries() {
 
   local helper_script="${REPO_ROOT}/scripts/setup-lan-dns.sh"
 
-  if [[ "${ENABLE_LOCAL_DNS:-1}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
     msg "  Local DNS container disabled; skipping host entries helper"
     return 0
   fi
@@ -53,7 +53,7 @@ configure_local_dns_entries() {
 }
 
 run_host_dns_setup() {
-  if [[ "${ENABLE_LOCAL_DNS:-1}" -ne 1 ]]; then
+  if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 ]]; then
     msg "Skipping host DNS setup (--setup-host-dns) because ENABLE_LOCAL_DNS=0"
     return 0
   fi

--- a/scripts/permissions.sh
+++ b/scripts/permissions.sh
@@ -57,7 +57,7 @@ verify_permissions() {
   local service
   for service in "${ARR_DOCKER_SERVICES[@]}"; do
     if [[ "$service" == "local_dns" ]]; then
-      if [[ "${ENABLE_LOCAL_DNS:-1}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
+      if [[ "${ENABLE_LOCAL_DNS:-0}" -ne 1 || ${LOCAL_DNS_SERVICE_ENABLED:-0} -ne 1 ]]; then
         continue
       fi
     fi


### PR DESCRIPTION
## Summary
- expose every service on the LAN IP from the Gluetun service, keep Caddy/DNS behind opt-in profiles, and set defaults/env templates to `EXPOSE_DIRECT_PORTS=1` with matching firewall allowances.
- gate installer steps and helpers so Caddy/local DNS assets only render when enabled while the summary highlights the new IP:PORT endpoints.
- rewrite the quick start and docs to stress IP-based access as the baseline and clarify that reverse proxy and DNS profiles are optional follow-ups.

## Testing
- shellcheck arrstack.sh scripts/defaults.sh scripts/files.sh scripts/services.sh scripts/summary.sh scripts/doctor.sh scripts/dns.sh scripts/permissions.sh arrconf/userconf.defaults.sh arrconf/userconf.sh.example # (SC1091 informational notices for sourced files)
- bash -n arrstack.sh scripts/defaults.sh scripts/files.sh scripts/services.sh scripts/summary.sh scripts/doctor.sh scripts/dns.sh scripts/permissions.sh arrconf/userconf.defaults.sh arrconf/userconf.sh.example
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d445a9a3988329af80571ae268a3db