### PR TITLE
refactor(common): centralize temp file helpers

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -12,8 +12,10 @@ write_aliases_file() {
   fi
 
   local tmp_file
-  tmp_file="$(mktemp "${aliases_file}.XXXX")"
-  ensure_secret_file_mode "$tmp_file"
+  if ! tmp_file="$(arrstack_mktemp_file "${aliases_file}.XXXX" "$SECRET_FILE_MODE")"; then
+    warn "Failed to create temporary aliases file"
+    return 1
+  fi
 
   local stack_dir_escaped env_file_escaped docker_dir_escaped arrconf_dir_escaped
   stack_dir_escaped=${ARR_STACK_DIR//\\/\\\\}
@@ -173,8 +175,10 @@ log_info "Diagnostics complete!"
 DIAG
 
   local diag_tmp
-  diag_tmp="$(mktemp "${diag_script}.XXXX")"
-  chmod 600 "$diag_tmp" 2>/dev/null || true
+  if ! diag_tmp="$(arrstack_mktemp_file "${diag_script}.XXXX")"; then
+    warn "Failed to create temporary diagnostic script"
+    return 1
+  fi
   local diag_dir_escaped
   diag_dir_escaped=${ARR_STACK_DIR//\\/\\\\}
   diag_dir_escaped=${diag_dir_escaped//&/\&}

--- a/scripts/files.sh
+++ b/scripts/files.sh
@@ -214,8 +214,7 @@ write_env() {
   fi
   QBT_AUTH_WHITELIST="$(normalize_csv "$qbt_whitelist_raw")"
   local tmp
-  tmp="$(mktemp "${ARR_ENV_FILE}.XXXXXX.tmp" 2>/dev/null)" || die "Failed to create temp file for ${ARR_ENV_FILE}"
-  chmod 600 "$tmp" 2>/dev/null || true
+  tmp="$(arrstack_mktemp_file "${ARR_ENV_FILE}.XXXXXX.tmp")" || die "Failed to create temp file for ${ARR_ENV_FILE}"
 
   {
     printf '# Core settings\n'
@@ -346,7 +345,7 @@ write_compose() {
       fi
     fi
 
-    tmp="$(mktemp "${compose_path}.XXXXXX.tmp" 2>/dev/null)" || die "Failed to create temp file for ${compose_path}"
+    tmp="$(arrstack_mktemp_file "${compose_path}.XXXXXX.tmp" "$NONSECRET_FILE_MODE")" || die "Failed to create temp file for ${compose_path}"
     ensure_nonsecret_file_mode "$tmp"
 
     cat <<'YAML' >"$tmp"

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -166,7 +166,9 @@ update_whitelist() {
   cfg=$(config_file_path)
   if [[ -f "$cfg" ]]; then
     local tmp
-    tmp=$(mktemp)
+    if ! tmp=$(arrstack_mktemp_file); then
+      die "Failed to create temporary whitelist file"
+    fi
     awk '!(/^WebUI\\AuthSubnetWhitelistEnabled=/ || /^WebUI\\AuthSubnetWhitelist=/)' "$cfg" >"$tmp"
     {
       printf 'WebUI\\AuthSubnetWhitelistEnabled=true\n'

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -28,8 +28,7 @@ install_vuetorrent() {
   fi
 
   local temp_extract=""
-  temp_extract="$(mktemp -d "/tmp/vuetorrent.XXXX" 2>/dev/null || printf '')"
-  if [[ -z "$temp_extract" ]]; then
+  if ! temp_extract="$(arrstack_mktemp_dir "/tmp/vuetorrent.XXXX")"; then
     rm -f "$temp_zip"
     warn "  Failed to create temporary directory for VueTorrent, continuing without it"
     return 0

--- a/scripts/setup-lan-dns.sh
+++ b/scripts/setup-lan-dns.sh
@@ -81,7 +81,9 @@ rewrite_hosts_file() {
   local content="$2"
   local tmp
 
-  tmp="$(mktemp "${file}.XXXXXX" 2>/dev/null)" || die "Unable to create temporary file for ${file}"
+  if ! tmp="$(arrstack_mktemp_file "${file}.XXXXXX")"; then
+    die "Unable to create temporary file for ${file}"
+  fi
   trap 'rm -f "${tmp}"' EXIT
 
   printf '%s\n' "${content}" >"${tmp}"
@@ -164,9 +166,8 @@ configure_docker_dns() {
     return 0
   fi
 
-  local tmp
-  tmp="$(mktemp "${daemon_json}.XXXXXX" 2>/dev/null || printf '')"
-  if [[ -z "${tmp}" ]]; then
+  local tmp=""
+  if ! tmp="$(arrstack_mktemp_file "${daemon_json}.XXXXXX" 644)"; then
     warn "Unable to create temporary file for ${daemon_json}; skipping Docker DNS configuration."
     return 1
   fi


### PR DESCRIPTION
## Summary
- add arrstack_mktemp_file and arrstack_mktemp_dir helpers for consistent temporary file handling
- refactor scripts to rely on the shared helpers and improve failure handling when temp files cannot be created
- ensure dev tooling sources common helpers so checks use the new patterns

## Testing
- shellcheck arrstack.sh
- shellcheck scripts/*.sh

------
https://chatgpt.com/codex/tasks/task_e_68d52e8d542483299f7e33b0cc53224b