### PR TITLE
refactor(preflight): reuse shared helpers

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -19,49 +19,6 @@ if [[ -f "${REPO_ROOT}/arrconf/userconf.sh" ]]; then
   . "${REPO_ROOT}/arrconf/userconf.sh"
 fi
 
-normalize_bind_address() {
-  local address="$1"
-
-  address="${address%%%*}"
-  address="${address#[}"
-  address="${address%]}"
-
-  if [[ "$address" == ::ffff:* ]]; then
-    address="${address##::ffff:}"
-  fi
-
-  if [[ -z "$address" ]]; then
-    address="*"
-  fi
-
-  printf '%s\n' "$address"
-}
-
-address_conflicts() {
-  local desired_raw="$1"
-  local actual_raw="$2"
-
-  local desired
-  local actual
-  desired="$(normalize_bind_address "$desired_raw")"
-  actual="$(normalize_bind_address "$actual_raw")"
-
-  if [[ "$desired" == "0.0.0.0" || "$desired" == "*" ]]; then
-    return 0
-  fi
-
-  case "$actual" in
-    "0.0.0.0" | "::" | "*")
-      return 0
-      ;;
-  esac
-
-  if [[ "$desired" == "$actual" ]]; then
-    return 0
-  fi
-
-  return 1
-}
 
 port_in_use_with_ss() {
   local proto="$1"


### PR DESCRIPTION
## Summary
- reuse `require_dependencies` in the preflight checks and tighten Docker Compose v2 detection and reporting
- delegate whitespace trimming to the shared helper while keeping a local fallback
- move port address helpers into `scripts/common.sh` so both preflight and the doctor script share the same logic

## Testing
- shellcheck scripts/preflight.sh scripts/common.sh scripts/doctor.sh
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d5b3a72de88329b5dd0acb44ae2e9d