### PR TITLE
fix: escape qbittorrent managed spec for awk

### DIFF
--- a/scripts/files.sh
+++ b/scripts/files.sh
@@ -1206,10 +1206,14 @@ EOF
   managed_spec+=$'WebUI\\HostHeaderValidation=true\n'
   managed_spec+="WebUI\\AuthSubnetWhitelist=${auth_whitelist}"
 
+  local managed_spec_for_awk
+  # Escape backslashes so awk -v does not treat sequences like \A as escapes
+  managed_spec_for_awk="${managed_spec//\\/\\\\}"
+
   local updated_content
   updated_content="$(
     printf '%s' "$source_content" \
-      | awk -v managed="$managed_spec" '
+      | awk -v managed="$managed_spec_for_awk" '
         BEGIN {
           FS = "=";
           OFS = "=";


### PR DESCRIPTION
## Summary
- escape the generated qBittorrent managed settings string before passing it to awk
- prevent awk from misinterpreting backslash-prefixed characters when rendering qBittorrent.conf

## Impact
- eliminates awk warnings during qBittorrent config generation while preserving expected whitelist entries

## Testing
- shellcheck scripts/files.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6b30726fc83298dbab38c749648e7