### PR TITLE
feat: accelerate ProtonVPN port forwarding handling

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -61,6 +61,11 @@ SERVER_COUNTRIES="${SERVER_COUNTRIES:-Netherlands}"
 # SERVER_NAMES=""  # Optionally pin Proton server hostnames if PF keeps returning 0 (comma-separated list)
 PVPN_ROTATE_COUNTRIES="${PVPN_ROTATE_COUNTRIES:-${SERVER_COUNTRIES}}"
 
+# ProtonVPN port forwarding behaviour (seconds)
+PF_MAX_TOTAL_WAIT="${PF_MAX_TOTAL_WAIT:-60}"
+PF_POLL_INTERVAL="${PF_POLL_INTERVAL:-5}"
+PF_CYCLE_AFTER="${PF_CYCLE_AFTER:-30}"
+
 # Domain suffix used by optional DNS/Caddy hostnames (default to RFC 8375 recommendation)
 LAN_DOMAIN_SUFFIX="${LAN_DOMAIN_SUFFIX:-home.arpa}"
 

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -84,6 +84,23 @@ WARNING
 WARNING
   fi
 
+  local pf_current=""
+  if declare -f fetch_forwarded_port >/dev/null 2>&1; then
+    pf_current="$(fetch_forwarded_port 2>/dev/null || printf '0')"
+  elif [[ -f "${ARR_DOCKER_DIR}/gluetun/forwarded_port" ]]; then
+    pf_current="$(tr -d '[:space:]' <"${ARR_DOCKER_DIR}/gluetun/forwarded_port" 2>/dev/null || printf '0')"
+  fi
+
+  if [[ "${PF_PENDING_DURING_INSTALL:-0}" -eq 1 && ( -z "$pf_current" || "$pf_current" == "0" ) ]]; then
+    cat <<'PF_WARNING'
+⚠️  PORT FORWARDING PENDING
+   Proton VPN did not return a forwarded port during setup.
+   Run `arr.vpn.port.sync` (or `arr.vpn.port`) after a minute to retry.
+   If the issue persists, consider pinning SERVER_COUNTRIES or SERVER_NAMES.
+
+PF_WARNING
+  fi
+
   cat <<SUMMARY
 Gluetun control server (local only): http://${LOCALHOST_IP}:${GLUETUN_CONTROL_PORT}
 


### PR DESCRIPTION
## Summary
- replace the Proton VPN port-forward wait loop with a configurable, time-budgeted poll that only cycles OpenVPN once
- continue stack start when a port is unavailable, trigger a quiet background retry, and surface the pending status in the summary output
- add defaults for the new tuning knobs to `userconf.defaults.sh` and improve the public IP status message for transient payloads

## Impact
- fresh installs unblock within ~60s even when Proton VPN reports port 0, while still retrying in the background
- operators now get a clear summary warning and guidance when port forwarding is pending, plus environment variables to tune the wait behaviour

## Actions for Host Users
- optionally adjust `PF_MAX_TOTAL_WAIT`, `PF_POLL_INTERVAL`, or `PF_CYCLE_AFTER` in `arrconf/userconf.sh` if you need different timing

## Testing
- shellcheck scripts/gluetun.sh scripts/services.sh scripts/summary.sh arrconf/userconf.defaults.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6bcd6e25883298949804f97dd724b