### PR TITLE
fix(compose): ensure consistent env sourcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends g
    ```bash
    ./arrstack.sh --yes
    ```
-   The script installs dependencies if needed, renders `.env`, and launches the stack with Docker Compose.
-   Compose reads `.env` automatically per [Docker’s env-file guidance](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-env-file).
+   The script installs dependencies if needed, renders `${ARR_STACK_DIR}/.env` (default `~/srv/arrstack/.env`), and launches the stack with Docker Compose from that directory.
+   Compose reads that `.env` automatically per [Docker’s env-file guidance](https://docs.docker.com/compose/environment-variables/set-environment-variables/#use-the-env-file).
 6. **Open the WebUIs directly by IP.** As soon as the installer finishes, browse to each service using your Pi’s LAN IP (example `192.168.1.50`). The installer refuses to expose ports until `LAN_IP` is a private address, so set the value and re-run if you skipped it the first time:
    - `http://192.168.1.50:8080` (qBittorrent)
    - `http://192.168.1.50:8989` (Sonarr)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -415,7 +415,20 @@ compose() {
     die "Docker Compose command not detected; run preflight first"
   fi
 
-  "${DOCKER_COMPOSE_CMD[@]}" "$@"
+  local project_dir="${ARR_STACK_DIR:-}"
+
+  if [[ -n "$project_dir" ]]; then
+    if [[ ! -d "$project_dir" ]]; then
+      die "Stack directory not found: ${project_dir}"
+    fi
+
+    (
+      cd "$project_dir" || die "Failed to change to ${project_dir}"
+      "${DOCKER_COMPOSE_CMD[@]}" "$@"
+    )
+  else
+    "${DOCKER_COMPOSE_CMD[@]}" "$@"
+  fi
 }
 
 msg_color_supported() {

--- a/scripts/fix-versions.sh
+++ b/scripts/fix-versions.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-ENV_FILE="${STACK_DIR}/.env"
+STACK_DIR_DEFAULT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STACK_DIR="${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}"
+if ! STACK_DIR="$(cd "${STACK_DIR}" 2>/dev/null && pwd)"; then
+  echo "Stack directory not found: ${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}" >&2
+  exit 1
+fi
+ENV_FILE="${ARR_ENV_FILE:-${STACK_DIR}/.env}"
 
 # shellcheck source=scripts/common.sh
 . "${STACK_DIR}/scripts/common.sh"

--- a/scripts/install-caddy-ca.sh
+++ b/scripts/install-caddy-ca.sh
@@ -43,13 +43,18 @@ while (($#)); do
 done
 
 if [[ -z "$STACK_DIR" ]]; then
-  STACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  STACK_DIR="${ARR_STACK_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+fi
+
+STACK_DIR_INPUT="$STACK_DIR"
+if ! STACK_DIR="$(cd "$STACK_DIR_INPUT" 2>/dev/null && pwd)"; then
+  die "Stack directory not found: ${STACK_DIR_INPUT}"
 fi
 
 if [[ -n "$DATA_DIR_OVERRIDE" ]]; then
   CADDY_DATA_DIR="$DATA_DIR_OVERRIDE"
 else
-  ENV_FILE="${STACK_DIR}/.env"
+  ENV_FILE="${ARR_ENV_FILE:-${STACK_DIR}/.env}"
   if [[ -f "$ENV_FILE" ]]; then
     env_value="$(grep '^ARR_DOCKER_DIR=' "$ENV_FILE" | head -n1 | cut -d= -f2- || true)"
     if [[ -n "$env_value" ]]; then

--- a/scripts/qbt-helper.sh
+++ b/scripts/qbt-helper.sh
@@ -4,12 +4,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STACK_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STACK_DIR_DEFAULT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STACK_DIR="${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}"
+if ! STACK_DIR="$(cd "${STACK_DIR}" 2>/dev/null && pwd)"; then
+  echo "Stack directory not found: ${ARR_STACK_DIR:-${STACK_DIR_DEFAULT}}" >&2
+  exit 1
+fi
 
 # shellcheck source=scripts/common.sh
 . "${STACK_DIR}/scripts/common.sh"
 
-ENV_FILE="${STACK_DIR}/.env"
+ENV_FILE="${ARR_ENV_FILE:-${STACK_DIR}/.env}"
 CONTAINER_NAME="qbittorrent"
 
 load_env() {


### PR DESCRIPTION
## Summary
- ensure the compose wrapper runs from the stack directory so docker compose always picks up the generated .env
- update helper scripts to respect ARR_STACK_DIR/ARR_ENV_FILE and refresh the Caddy dev check to look in the stack directory
- document the canonical location of the generated .env in the README

## Impact
- suppresses missing environment warnings by giving docker compose a single source of truth for configuration values

## Actions Required
- none

## Testing
- `shellcheck scripts/common.sh scripts/dev/check-caddy-optional.sh scripts/fix-versions.sh scripts/install-caddy-ca.sh scripts/qbt-helper.sh`

------
https://chatgpt.com/codex/tasks/task_e_68d6cc38d1608329b0a1aac56880713c