### PR TITLE
refactor(logging): streamline color environment toggles

### DIFF
--- a/arrconf/userconf.defaults.sh
+++ b/arrconf/userconf.defaults.sh
@@ -33,6 +33,7 @@ ARR_LOG_DIR="${ARR_LOG_DIR:-${ARR_STACK_DIR}/logs}"
 ARR_INSTALL_LOG="${ARR_INSTALL_LOG:-${ARR_LOG_DIR}/arrstack-install.log}"
 ARR_DOCKER_DIR="${ARR_DOCKER_DIR:-${ARR_BASE}/docker-data}"
 ARRCONF_DIR="${ARRCONF_DIR:-${REPO_ROOT:-${PWD}}/arrconf}"
+ARR_COLOR_OUTPUT="${ARR_COLOR_OUTPUT:-1}"
 
 # File/dir permissions (strict keeps secrets 600/700, collaborative loosens group access)
 if ! arrstack_var_is_readonly ARR_PERMISSION_PROFILE; then

--- a/arrconf/userconf.sh.example
+++ b/arrconf/userconf.sh.example
@@ -72,6 +72,7 @@ FLARESOLVERR_PORT="8191"               # FlareSolverr service port exposed on th
 # FLARESOLVERR_IMAGE="ghcr.io/flaresolverr/flaresolverr:v3.3.21"      # Override the FlareSolverr container tag
 
 # --- Behaviour toggles ---
+# ARR_COLOR_OUTPUT="1"                   # Set to 0 to disable coloured CLI output (default: 1)
 # ASSUME_YES="0"                         # Skip confirmation prompts when scripting installs
 # FORCE_ROTATE_API_KEY="0"               # Force regeneration of the Gluetun API key on next run
 # FORCE_REGEN_CADDY_AUTH="0"             # Rotate the Caddy username/password on next run

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,10 +3,38 @@
 : "${CYAN:=}"
 : "${YELLOW:=}"
 : "${RESET:=}"
+: "${ARR_COLOR_OUTPUT:=1}"
 : "${SECRET_FILE_MODE:=600}"
 : "${NONSECRET_FILE_MODE:=600}"
 : "${DATA_DIR_MODE:=700}"
 : "${LOCK_FILE_MODE:=600}"
+
+arrstack_resolve_color_output() {
+  if [[ -n "${NO_COLOR:-}" ]]; then
+    ARR_COLOR_OUTPUT=0
+    return
+  fi
+
+  case "${FORCE_COLOR:-}" in
+    '' | 0 | false | FALSE | no | NO)
+      ;;
+    *)
+      ARR_COLOR_OUTPUT=1
+      return
+      ;;
+  esac
+
+  case "${ARR_COLOR_OUTPUT:-1}" in
+    0 | false | FALSE | no | NO | off | OFF)
+      ARR_COLOR_OUTPUT=0
+      ;;
+    *)
+      ARR_COLOR_OUTPUT=1
+      ;;
+  esac
+}
+
+arrstack_resolve_color_output
 
 have_command() {
   command -v "$1" >/dev/null 2>&1
@@ -432,16 +460,13 @@ compose() {
 }
 
 msg_color_supported() {
-  if [ -n "${NO_COLOR:-}" ]; then
+  arrstack_resolve_color_output
+
+  if [[ "${ARR_COLOR_OUTPUT}" == 0 ]]; then
     return 1
   fi
-  if [ -n "${FORCE_COLOR:-}" ]; then
-    return 0
-  fi
-  if [ -t 1 ]; then
-    return 0
-  fi
-  return 1
+
+  return 0
 }
 
 arrstack_timestamp() {

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -47,6 +47,7 @@ arrstack_setup_defaults() {
   : "${DNS_DISTRIBUTION_MODE:=router}"
   : "${SETUP_HOST_DNS:=0}"
   : "${REFRESH_ALIASES:=0}"
+  : "${ARR_COLOR_OUTPUT:=1}"
 
   LOCAL_DNS_SERVICE_ENABLED=0
   : "$LOCAL_DNS_SERVICE_ENABLED" # referenced by other modules after defaults load


### PR DESCRIPTION
## Summary
- normalize ARR_COLOR_OUTPUT when common helpers load so NO_COLOR and FORCE_COLOR collapse into a single toggle
- rely on the normalized ARR_COLOR_OUTPUT flag for colorized logging checks

## Impact
- color output honors NO_COLOR, FORCE_COLOR, and ARR_COLOR_OUTPUT consistently without redundant conditionals

## Testing
- ./arrstack.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d713cd0bc0832983d862c031c145d6