### PR TITLE
permissions: auto-fix existing media dirs in collab; fix octal bitmask

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -209,7 +209,8 @@ arrstack_is_group_writable() {
 
   local numeric=$((8#$mode))
 
-  if (((numeric & 0o020) != 0)); then
+  # 020 = group write bit
+  if (((numeric & 020) != 0)); then
     return 0
   fi
 

--- a/scripts/permissions.sh
+++ b/scripts/permissions.sh
@@ -4,6 +4,7 @@ check_and_fix_mode() {
   local target="$1"
   local desired="$2"
   local issue_label="$3"
+  local silent_on_fix="${4:-0}"
 
   [[ -e "$target" ]] || return 0
 
@@ -11,14 +12,30 @@ check_and_fix_mode() {
   perms="$(stat -c '%a' "$target" 2>/dev/null || echo 'unknown')"
 
   if [[ "$perms" != "$desired" ]]; then
-    warn "  ${issue_label} on $target: $perms (should be $desired)"
+    local mismatch_logged=0
+    local mismatch_message
+    mismatch_message="  ${issue_label} on $target: $perms (should be $desired)"
+
+    if ((silent_on_fix == 0)); then
+      warn "$mismatch_message"
+      mismatch_logged=1
+    fi
+
     if chmod "$desired" "$target" 2>/dev/null; then
       perms="$(stat -c '%a' "$target" 2>/dev/null || echo 'unknown')"
       if [[ "$perms" != "$desired" ]]; then
+        if ((mismatch_logged == 0)); then
+          warn "$mismatch_message"
+          mismatch_logged=1
+        fi
         warn "  Permissions remain ${perms}; manual fix required for $target"
         return 1
       fi
       return 0
+    fi
+
+    if ((mismatch_logged == 0)); then
+      warn "$mismatch_message"
     fi
     warn "  Could not fix permissions on $target"
     return 1
@@ -36,6 +53,58 @@ verify_permissions() {
   fi
 
   msg "🔒 Verifying file permissions"
+
+  collab_warn_permission_failure() {
+    local message="$1"
+
+    if [[ -z "$message" ]]; then
+      return 0
+    fi
+
+    local already_listed=0
+    if [[ -n "${COLLAB_PERMISSION_WARNINGS:-}" ]]; then
+      local padded=$'\n'"${COLLAB_PERMISSION_WARNINGS}"$'\n'
+      local needle=$'\n'"${message}"$'\n'
+      if [[ "$padded" == *"${needle}"* ]]; then
+        already_listed=1
+      fi
+    fi
+
+    if ((already_listed == 0)); then
+      warn "$message"
+    fi
+
+    arrstack_append_collab_warning "$message"
+  }
+
+  collab_try_fix_dir() {
+    local dir="$1"
+
+    if [[ -z "$dir" || ! -d "$dir" ]]; then
+      return 0
+    fi
+
+    chmod "$DATA_DIR_MODE" "$dir" 2>/dev/null || true
+
+    if arrstack_is_group_writable "$dir"; then
+      return 0
+    fi
+
+    return 1
+  }
+
+  collab_warn_label_failure() {
+    local dir="$1"
+    local label="$2"
+
+    if [[ -z "$dir" || -z "$label" ]]; then
+      return 0
+    fi
+
+    local message
+    message="${label} directory not group-writable and could not apply ${DATA_DIR_MODE} (collab) — fix manually: ${dir}"
+    collab_warn_permission_failure "$message"
+  }
 
   local -a secret_files=(
     "${ARR_ENV_FILE}"
@@ -81,11 +150,9 @@ verify_permissions() {
   local dir
   for dir in "${data_dirs[@]}"; do
     if [[ -d "$dir" ]]; then
-      if ! check_and_fix_mode "$dir" "$DATA_DIR_MODE" "Loose permissions"; then
-        if ((collab_enabled)); then
-          if ! arrstack_is_group_writable "$dir"; then
-            arrstack_append_collab_warning "${dir} is not group-writable; adjust manually to let the media group manage container data"
-          fi
+      if ! check_and_fix_mode "$dir" "$DATA_DIR_MODE" "Loose permissions" 1; then
+        if ((collab_enabled)) && ! collab_try_fix_dir "$dir"; then
+          collab_warn_permission_failure "${dir} is not group-writable; adjust manually to let the media group manage container data"
         fi
         ((issues++))
       fi
@@ -94,18 +161,18 @@ verify_permissions() {
 
   if ((collab_enabled)); then
     if [[ -d "${DOWNLOADS_DIR}" ]]; then
-      if ! check_and_fix_mode "${DOWNLOADS_DIR}" "$DATA_DIR_MODE" "Loose permissions"; then
-        if ! arrstack_is_group_writable "${DOWNLOADS_DIR}"; then
-          arrstack_append_collab_warning "${DOWNLOADS_DIR} is not group-writable; adjust manually so secondary users can write downloads"
+      if ! check_and_fix_mode "${DOWNLOADS_DIR}" "$DATA_DIR_MODE" "Loose permissions" 1; then
+        if ! collab_try_fix_dir "${DOWNLOADS_DIR}"; then
+          collab_warn_label_failure "${DOWNLOADS_DIR}" "Downloads"
         fi
         ((issues++))
       fi
     fi
 
     if [[ -d "${COMPLETED_DIR}" ]]; then
-      if ! check_and_fix_mode "${COMPLETED_DIR}" "$DATA_DIR_MODE" "Loose permissions"; then
-        if ! arrstack_is_group_writable "${COMPLETED_DIR}"; then
-          arrstack_append_collab_warning "${COMPLETED_DIR} is not group-writable; adjust manually so post-processing can move files"
+      if ! check_and_fix_mode "${COMPLETED_DIR}" "$DATA_DIR_MODE" "Loose permissions" 1; then
+        if ! collab_try_fix_dir "${COMPLETED_DIR}"; then
+          collab_warn_label_failure "${COMPLETED_DIR}" "Completed"
         fi
         ((issues++))
       fi
@@ -118,9 +185,9 @@ verify_permissions() {
       while IFS= read -r collab_created_dir; do
         [[ -z "$collab_created_dir" ]] && continue
         if [[ -d "$collab_created_dir" ]]; then
-          if ! check_and_fix_mode "$collab_created_dir" "$DATA_DIR_MODE" "Loose permissions"; then
-            if ! arrstack_is_group_writable "$collab_created_dir"; then
-              arrstack_append_collab_warning "${collab_created_dir} is not group-writable; adjust manually so the media apps can manage it"
+          if ! check_and_fix_mode "$collab_created_dir" "$DATA_DIR_MODE" "Loose permissions" 1; then
+            if ! collab_try_fix_dir "$collab_created_dir"; then
+              collab_warn_permission_failure "${collab_created_dir} is not group-writable; adjust manually so the media apps can manage it"
             fi
             ((issues++))
           fi
@@ -148,8 +215,21 @@ verify_permissions() {
         if ((already_tracked)); then
           continue
         fi
-        if ! arrstack_is_group_writable "$media_dir"; then
-          arrstack_append_collab_warning "${media_dir} stays non-group-writable (existing library); update manually if the media group should write here"
+        if ! collab_try_fix_dir "$media_dir"; then
+          local label=""
+          if [[ -n "${TV_DIR:-}" && "$media_dir" == "$TV_DIR" ]]; then
+            label="TV"
+          elif [[ -n "${MOVIES_DIR:-}" && "$media_dir" == "$MOVIES_DIR" ]]; then
+            label="Movies"
+          elif [[ -n "${SUBS_DIR:-}" && "$media_dir" == "$SUBS_DIR" ]]; then
+            label="Subtitles"
+          fi
+
+          if [[ -n "$label" ]]; then
+            collab_warn_label_failure "$media_dir" "$label"
+          else
+            collab_warn_permission_failure "${media_dir} stays non-group-writable (existing library); update manually if the media group should write here"
+          fi
         fi
       fi
     done


### PR DESCRIPTION
## Summary
- fix the group-writable bitmask helper to use POSIX-compliant syntax
- automatically remediate collaborative downloads/completed/media directories and warn only if chmod fails
- update the permission verifier to retry chmod before warning and suppress duplicate loose-permission messages

## Testing
- shellcheck scripts/common.sh scripts/files.sh scripts/permissions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d72f1a5b508329aa46d35a8c256343