### PR TITLE
Add Configarr sync helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ LOCALHOST_IP=127.0.0.1
 EXPOSE_DIRECT_PORTS=1
 ENABLE_CADDY=0
 
+# Optional tooling
+ENABLE_CONFIGARR=1
+
 # Local DNS (disabled by default)
 # Preferred comma-separated chain (legacy UPSTREAM_DNS_1/UPSTREAM_DNS_2 remain supported).
 LAN_DOMAIN_SUFFIX=home.arpa
@@ -72,4 +75,5 @@ RADARR_IMAGE=lscr.io/linuxserver/radarr:5.27.5.10198-ls283
 PROWLARR_IMAGE=lscr.io/linuxserver/prowlarr:latest
 BAZARR_IMAGE=lscr.io/linuxserver/bazarr:latest
 FLARESOLVERR_IMAGE=ghcr.io/flaresolverr/flaresolverr:v3.3.21
+CONFIGARR_IMAGE=ghcr.io/raydak-labs/configarr:latest
 CADDY_IMAGE=caddy:2.8.4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ arrconf/*2.sh
 
 # Runtime data
 docker-data/
+docker-data/configarr/secrets.yml
+docker-data/configarr/cfs/
 downloads/
 completed/
 media/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ You should see an HTTP 200/302 response. If not, re-run the installer and confir
 - `./scripts/doctor.sh` performs the same LAN DNS and port checks the installer runs automatically; re-run it when troubleshooting.
 - `ARRSTACK_DEBUG_PORTS=1 ./arrstack.sh` writes `logs/port-scan-*.jsonl` snapshots for each port check so you can diagnose who bound a port.
 
+## Configarr (TRaSH-Guides Sync)
+
+Configarr runs as a one-shot helper to import TRaSH-Guides quality definitions, profiles, and custom formats into Sonarr v4 and Radarr v5. It is enabled by default; set `ENABLE_CONFIGARR=0` in `userr.conf` (or your environment) to omit the container on the next install run. Run Configarr only after Sonarr and Radarr have completed their first boot and database migrations.
+
+- The installer seeds `docker-data/configarr/config.yml` with the default TRaSH-Guides templates and creates `docker-data/configarr/secrets.yml` with placeholder API keys. Populate that secrets file (or swap to `!env` in `config.yml`) before syncing.
+- Trigger a manual sync with `arr.config.sync` (added to `.aliasarr` when Configarr is enabled) or directly via `docker compose run --rm configarr` from the stack directory. The container exits after a single run.
+- To schedule recurring updates on the host, add a cron entry such as:<br>`10 3 * * SUN cd /path/to/arrstack && docker compose run --rm configarr >> logs/configarr-sync.log 2>&1`
+- Local custom formats can be stored in `docker-data/configarr/cfs` and referenced from `config.yml` as needed.
+- Update `CONFIGARR_IMAGE` in `.env`/`userr.conf` if you want to pin a specific Configarr image tag.
+
 ## Permission profiles
 `arrstack.sh` defaults to the **strict** permission profile so secrets stay private (files `600`, data directories `700`, umask `0077`). Switch to the **collab** profile when you run multiple media managers, SMB/NFS shares, or post-processing scripts that need to write into the stack:
 

--- a/arrconf/userr.conf.defaults.sh
+++ b/arrconf/userr.conf.defaults.sh
@@ -152,6 +152,7 @@ fi
 # Enable internal local DNS resolver service
 ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS:-0}"
 ENABLE_CADDY="${ENABLE_CADDY:-0}"
+ENABLE_CONFIGARR="${ENABLE_CONFIGARR:-1}"
 
 # How LAN clients learn the resolver address
 #   router     – configure DHCP Option 6 on your router to ${LAN_IP}
@@ -207,6 +208,7 @@ RADARR_IMAGE="${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.27.5.10198-ls283}"
 PROWLARR_IMAGE="${PROWLARR_IMAGE:-lscr.io/linuxserver/prowlarr:latest}"
 BAZARR_IMAGE="${BAZARR_IMAGE:-lscr.io/linuxserver/bazarr:latest}"
 FLARESOLVERR_IMAGE="${FLARESOLVERR_IMAGE:-ghcr.io/flaresolverr/flaresolverr:v3.3.21}"
+CONFIGARR_IMAGE="${CONFIGARR_IMAGE:-ghcr.io/raydak-labs/configarr:latest}"
 CADDY_IMAGE="${CADDY_IMAGE:-caddy:2.8.4}"
 #
 # Behaviour flags
@@ -229,6 +231,7 @@ ARRSTACK_USERCONF_TEMPLATE_VARS=(
   GLUETUN_CONTROL_PORT
   ENABLE_LOCAL_DNS
   ENABLE_CADDY
+  ENABLE_CONFIGARR
   DNS_DISTRIBUTION_MODE
   UPSTREAM_DNS_SERVERS
   UPSTREAM_DNS_1
@@ -252,6 +255,7 @@ ARRSTACK_USERCONF_TEMPLATE_VARS=(
   PROWLARR_IMAGE
   BAZARR_IMAGE
   FLARESOLVERR_IMAGE
+  CONFIGARR_IMAGE
 )
 
 # shellcheck disable=SC2034  # exported for template rendering via envsubst
@@ -320,6 +324,7 @@ PVPN_ROTATE_COUNTRIES="${PVPN_ROTATE_COUNTRIES}"  # Optional rotation order for 
 GLUETUN_CONTROL_PORT="${GLUETUN_CONTROL_PORT}"            # Host port that exposes the Gluetun control API (default: ${GLUETUN_CONTROL_PORT})
 ENABLE_LOCAL_DNS="${ENABLE_LOCAL_DNS}"                   # Advanced: enable the optional dnsmasq container (0/1, default: ${ENABLE_LOCAL_DNS})
 ENABLE_CADDY="${ENABLE_CADDY}"                       # Optional Caddy reverse proxy (run ./arrstack.sh --enable-caddy or set 1 to add HTTPS hostnames)
+ENABLE_CONFIGARR="${ENABLE_CONFIGARR}"             # Configarr one-shot sync for TRaSH-Guides profiles (set 0 to omit the container)
 DNS_DISTRIBUTION_MODE="${DNS_DISTRIBUTION_MODE}"         # router (DHCP Option 6) or per-device DNS settings (default: ${DNS_DISTRIBUTION_MODE})
 UPSTREAM_DNS_SERVERS="${UPSTREAM_DNS_SERVERS}"          # Comma-separated resolver list used by dnsmasq (default chain shown)
 UPSTREAM_DNS_1="${UPSTREAM_DNS_1}"               # Legacy primary resolver override (default derived: ${UPSTREAM_DNS_1})
@@ -352,6 +357,7 @@ FLARESOLVERR_PORT="${FLARESOLVERR_PORT}"               # FlareSolverr service po
 # PROWLARR_IMAGE="${PROWLARR_IMAGE}"                # Override the Prowlarr container tag
 # BAZARR_IMAGE="${BAZARR_IMAGE}"                    # Override the Bazarr container tag
 # FLARESOLVERR_IMAGE="${FLARESOLVERR_IMAGE}"      # Override the FlareSolverr container tag
+# CONFIGARR_IMAGE="${CONFIGARR_IMAGE}"            # Override the Configarr container tag
 
 # --- Behaviour toggles ---
 # ASSUME_YES="0"                         # Skip confirmation prompts when scripting installs

--- a/arrconf/userr.conf.example
+++ b/arrconf/userr.conf.example
@@ -38,6 +38,7 @@ PVPN_ROTATE_COUNTRIES="Netherlands"  # Optional rotation order for arr.vpn switc
 GLUETUN_CONTROL_PORT="8000"            # Host port that exposes the Gluetun control API (default: 8000)
 ENABLE_LOCAL_DNS="0"                   # Advanced: enable the optional dnsmasq container (0/1, default: 0)
 ENABLE_CADDY="0"                       # Optional Caddy reverse proxy (run ./arrstack.sh --enable-caddy or set 1 to add HTTPS hostnames)
+ENABLE_CONFIGARR="1"             # Configarr one-shot sync for TRaSH-Guides profiles (set 0 to omit the container)
 DNS_DISTRIBUTION_MODE="router"         # router (DHCP Option 6) or per-device DNS settings (default: router)
 UPSTREAM_DNS_SERVERS="1.1.1.1,1.0.0.1"          # Comma-separated resolver list used by dnsmasq (default chain shown)
 UPSTREAM_DNS_1="1.1.1.1"               # Legacy primary resolver override (default derived: 1.1.1.1)
@@ -70,6 +71,7 @@ FLARESOLVERR_PORT="8191"               # FlareSolverr service port exposed on th
 # PROWLARR_IMAGE="lscr.io/linuxserver/prowlarr:latest"                # Override the Prowlarr container tag
 # BAZARR_IMAGE="lscr.io/linuxserver/bazarr:latest"                    # Override the Bazarr container tag
 # FLARESOLVERR_IMAGE="ghcr.io/flaresolverr/flaresolverr:v3.3.21"      # Override the FlareSolverr container tag
+# CONFIGARR_IMAGE="ghcr.io/raydak-labs/configarr:latest"            # Override the Configarr container tag
 
 # --- Behaviour toggles ---
 # ASSUME_YES="0"                         # Skip confirmation prompts when scripting installs

--- a/arrstack.sh
+++ b/arrstack.sh
@@ -151,6 +151,7 @@ main() {
   if [[ "${SETUP_HOST_DNS:-0}" -eq 1 ]]; then
     run_host_dns_setup
   fi
+  write_configarr_assets
   verify_permissions
   install_aliases
   start_stack

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -45,6 +45,15 @@ write_aliases_file() {
 
   mv "$tmp_file" "$aliases_file"
 
+  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+    if ! grep -Fq "alias arr.config.sync" "$aliases_file" 2>/dev/null; then
+      {
+        printf '\n# Configarr helper\n'
+        printf "alias arr.config.sync='docker compose run --rm configarr'\n"
+      } >>"$aliases_file"
+    fi
+  fi
+
   ensure_secret_file_mode "$aliases_file"
   cp "$aliases_file" "$configured_template"
   ensure_nonsecret_file_mode "$configured_template"

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -44,6 +44,7 @@ arrstack_setup_defaults() {
 
   : "${ENABLE_LOCAL_DNS:=0}"
   : "${ENABLE_CADDY:=0}"
+  : "${ENABLE_CONFIGARR:=1}"
   : "${DNS_DISTRIBUTION_MODE:=router}"
   : "${SETUP_HOST_DNS:=0}"
   : "${REFRESH_ALIASES:=0}"
@@ -94,6 +95,7 @@ arrstack_setup_defaults() {
   : "${PROWLARR_IMAGE:=lscr.io/linuxserver/prowlarr:latest}"
   : "${BAZARR_IMAGE:=lscr.io/linuxserver/bazarr:latest}"
   : "${FLARESOLVERR_IMAGE:=ghcr.io/flaresolverr/flaresolverr:v3.3.21}"
+  : "${CONFIGARR_IMAGE:=ghcr.io/raydak-labs/configarr:latest}"
 
   if [[ -n "${CADDY_DOMAIN_SUFFIX:-}" ]]; then
     CADDY_DOMAIN_SUFFIX="${CADDY_DOMAIN_SUFFIX#.}"
@@ -214,7 +216,7 @@ arrstack_setup_defaults() {
   COLLAB_CREATED_MEDIA_DIRS=""
   : "$COLLAB_PERMISSION_WARNINGS" "$COLLAB_CREATED_MEDIA_DIRS"
 
-  ARR_DOCKER_SERVICES=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr caddy local_dns)
+  ARR_DOCKER_SERVICES=(gluetun qbittorrent sonarr radarr prowlarr bazarr flaresolverr configarr caddy local_dns)
   : "${ARR_DOCKER_SERVICES[*]}"
   readonly -a ARR_DOCKER_SERVICES
 

--- a/scripts/permissions.sh
+++ b/scripts/permissions.sh
@@ -112,6 +112,7 @@ verify_permissions() {
     "${ARRCONF_DIR}/proton.auth"
     "${ARR_DOCKER_DIR}/qbittorrent/qBittorrent.conf"
     "${ARR_STACK_DIR}/.aliasarr"
+    "${ARR_DOCKER_DIR}/configarr/secrets.yml"
   )
 
   local file
@@ -126,6 +127,7 @@ verify_permissions() {
   local -a nonsecret_files=(
     "${ARR_STACK_DIR}/docker-compose.yml"
     "${REPO_ROOT}/.aliasarr.configured"
+    "${ARR_DOCKER_DIR}/configarr/config.yml"
   )
 
   for file in "${nonsecret_files[@]}"; do

--- a/scripts/services.sh
+++ b/scripts/services.sh
@@ -371,6 +371,10 @@ validate_images() {
     FLARESOLVERR_IMAGE
   )
 
+  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+    image_vars+=(CONFIGARR_IMAGE)
+  fi
+
   if [[ "${ENABLE_CADDY:-0}" -eq 1 ]]; then
     image_vars+=(CADDY_IMAGE)
   fi

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -132,6 +132,21 @@ WARNING
     done < <(printf '%s\n' "${COLLAB_PERMISSION_WARNINGS}")
   fi
 
+  if [[ "${ENABLE_CONFIGARR:-0}" -eq 1 ]]; then
+    local configarr_config="${ARR_DOCKER_DIR}/configarr/config.yml"
+    local configarr_secrets="${ARR_DOCKER_DIR}/configarr/secrets.yml"
+    cat <<CONFIGARR
+Configarr:
+  Manual sync: arr.config.sync
+  Config:      ${configarr_config}
+  Secrets:     ${configarr_secrets}
+
+CONFIGARR
+    if [[ -f "$configarr_secrets" ]] && grep -Fq 'REPLACE_WITH_' "$configarr_secrets"; then
+      warn "Add Sonarr/Radarr API keys to ${configarr_secrets} then rerun arr.config.sync."
+    fi
+  fi
+
   cat <<SUMMARY
 Gluetun control server (local only): http://${LOCALHOST_IP}:${GLUETUN_CONTROL_PORT}
 


### PR DESCRIPTION
## Summary
- enable the Configarr container by default with environment defaults, compose integration, and a manual arr.config.sync alias
- scaffold Configarr configuration and secrets with built-in defaults and permission verification
- document usage in the README and update user config templates for the new toggle and image override

## Testing
- shellcheck arrstack.sh scripts/defaults.sh scripts/files.sh scripts/aliases.sh scripts/summary.sh scripts/permissions.sh scripts/services.sh arrconf/userr.conf.defaults.sh arrconf/userr.conf.example (warnings: existing SC1091/SC2016/SC2034)


------
https://chatgpt.com/codex/tasks/task_e_68d753a865e083299595b9a631a31890