### PR TITLE
Fix userconf template to use relative log paths

### DIFF
--- a/arrconf/userr.conf.defaults.sh
+++ b/arrconf/userr.conf.defaults.sh
@@ -354,7 +354,23 @@ arrstack_export_userconf_template_vars() {
   local value=""
 
   for var in "${ARRSTACK_USERCONF_TEMPLATE_VARS[@]}"; do
-    value="${!var-}"
+    case "$var" in
+      ARR_USERCONF_PATH)
+        # shellcheck disable=SC2016  # keep literal reference for template output
+        value='${ARR_BASE}/userr.conf'
+        ;;
+      ARR_LOG_DIR)
+        # shellcheck disable=SC2016  # keep literal reference for template output
+        value='${ARR_STACK_DIR}/logs'
+        ;;
+      ARR_INSTALL_LOG)
+        # shellcheck disable=SC2016  # keep literal reference for template output
+        value='${ARR_LOG_DIR}/arrstack-install.log'
+        ;;
+      *)
+        value="${!var-}"
+        ;;
+    esac
     export "${var}=${value}"
   done
 }

--- a/arrconf/userr.conf.example
+++ b/arrconf/userr.conf.example
@@ -9,12 +9,12 @@ ARR_BASE="${HOME}/srv"                 # Root directory for generated stack file
 ARR_STACK_DIR="${ARR_BASE}/arrstack"  # Location for docker-compose.yml, scripts, and aliases
 ARR_ENV_FILE="${ARR_STACK_DIR}/.env"  # Path to the generated .env secrets file
 ARR_DOCKER_DIR="${ARR_BASE}/docker-data"  # Docker volumes and persistent data storage
-# ARR_USERCONF_PATH="/root/srv/userr.conf"  # Optional: relocate this file outside ${ARR_BASE}
+# ARR_USERCONF_PATH="${ARR_BASE}/userr.conf"  # Optional: relocate this file outside ${ARR_BASE}
 # ARRCONF_DIR="${HOME}/.config/arrstack"  # Optional: relocate Proton creds outside the repo
 
 # --- Logging and output ---
-ARR_LOG_DIR="/root/srv/arrstack/logs"           # Directory for runtime/service logs (default: /root/srv/arrstack/logs)
-ARR_INSTALL_LOG="/root/srv/arrstack/logs/arrstack-install.log"   # Installer run log location (default: /root/srv/arrstack/logs/arrstack-install.log)
+ARR_LOG_DIR="${ARR_STACK_DIR}/logs"           # Directory for runtime/service logs (default: ${ARR_STACK_DIR}/logs)
+ARR_INSTALL_LOG="${ARR_LOG_DIR}/arrstack-install.log"   # Installer run log location (default: ${ARR_LOG_DIR}/arrstack-install.log)
 ARR_COLOR_OUTPUT="1"       # 1 keeps colorful CLI output, set 0 to disable ANSI colors
 
 # --- Permissions ---


### PR DESCRIPTION
## Summary
- ensure the userconf template exports ARR_USERCONF_PATH, ARR_LOG_DIR, and ARR_INSTALL_LOG as relative placeholders
- regenerate arrconf/userr.conf.example so the default log locations track ARR_STACK_DIR instead of /root paths that fail for non-root users

## Testing
- shellcheck arrconf/userr.conf.defaults.sh


------
https://chatgpt.com/codex/tasks/task_e_68d7bebfa3d48329a660d843b5c0bd7d